### PR TITLE
feat: ui tweaks to bring design closer to other libadwaita applications

### DIFF
--- a/resources/ui/album_list.ui
+++ b/resources/ui/album_list.ui
@@ -85,6 +85,7 @@
                 <property name="max-columns">10</property>
                 <property name="single-click-activate">true</property>
                 <property name="visible">false</property>
+                <property name="css-classes"></property>
               </object>
             </child>
           </object>

--- a/resources/ui/artist_list.ui
+++ b/resources/ui/artist_list.ui
@@ -82,6 +82,7 @@
                 <property name="max-columns">10</property>
                 <property name="single-click-activate">true</property>
                 <property name="visible">false</property>
+                <property name="css-classes"></property>
               </object>
             </child>
           </object>

--- a/resources/ui/playlist_list.ui
+++ b/resources/ui/playlist_list.ui
@@ -82,6 +82,7 @@
                 <property name="max-columns">10</property>
                 <property name="single-click-activate">true</property>
                 <property name="visible">false</property>
+                <property name="css-classes"></property>
               </object>
             </child>
           </object>

--- a/resources/ui/setup.ui
+++ b/resources/ui/setup.ui
@@ -9,9 +9,8 @@
           <object class="AdwNavigationPage" id="setup_servers">
             <property name="title" translatable="yes">Servers</property>
             <child>
-              <object class="GtkBox">
-                <property name="orientation">1</property>
-                <child>
+              <object class="AdwToolbarView">
+                <child type="top">
                   <object class="AdwHeaderBar" id="setup_header_bar">
                     <property name="title-widget">
                       <object class="AdwWindowTitle">
@@ -20,7 +19,7 @@
                     </property>
                   </object>
                 </child>
-                <child>
+                <property name="content">
                   <object class="GtkBox">
                     <property name="orientation">1</property>
                     <property name="halign">3</property>
@@ -62,32 +61,25 @@
                       </object>
                     </child>
                     <child>
-                      <object class="GtkListBox">
+                      <object class="GtkButton" id="connect_button">
+                        <property name="label">Connect</property>
+                        <property name="sensitive">false</property>
                         <style>
-                          <class name="boxed-list"/>
+                          <class name="suggested-action"/>
+                          <class name="pill"/>
                         </style>
-                        <child>
-                          <object class="AdwButtonRow" id="connect_button">
-                            <property name="title">Connect</property>
-                            <property name="sensitive">false</property>
-                            <style>
-                              <class name="suggested-action"/>
-                            </style>
-                          </object>
-                        </child>
                       </object>
                     </child>
                   </object>
-                </child>
+                </property>
               </object>
             </child>
           </object>
           <object class="AdwNavigationPage" id="setup_library">
             <property name="title">Choose Library</property>
             <child>
-              <object class="GtkBox">
-                <property name="orientation">1</property>
-                <child>
+              <object class="AdwToolbarView">
+                <child type="top">
                   <object class="AdwHeaderBar" id="setup_library_header_bar">
                     <property name="title-widget">
                       <object class="AdwWindowTitle">
@@ -96,17 +88,18 @@
                     </property>
                   </object>
                 </child>
-                <child>
+                <property name="content">
                   <object class="GtkBox">
                     <property name="orientation">vertical</property>
                     <property name="halign">center</property>
                     <property name="hexpand">true</property>
+                    <property name="spacing">24</property>
+                    <property name="margin-bottom">24</property>
+                    <property name="margin-top">24</property>
                     <child>
                       <object class="GtkLabel">
                         <property name="label" translatable="yes">Select music library</property>
                         <property name="wrap">true</property>
-                        <property name="margin-bottom">24</property>
-                        <property name="margin-top">24</property>
                         <style>
                           <class name="title-1"/>
                         </style>
@@ -115,7 +108,6 @@
                     <child>
                       <object class="GtkListBox" id="library_list">
                         <property name="selection-mode">none</property>
-                        <property name="margin-bottom">24</property>
                         <style>
                           <class name="boxed-list"/>
                         </style>
@@ -127,32 +119,27 @@
                       </object>
                     </child>
                     <child>
-                      <object class="GtkListBox">
-                        <property name="margin-bottom">24</property>
+                      <object class="GtkButton" id="library_button">
+                        <property name="label">Launch Gelly</property>
+                        <property name="sensitive">false</property>
                         <style>
-                          <class name="boxed-list"/>
+                          <class name="suggested-action"/>
+                          <class name="pill"/>
                         </style>
-                        <child>
-                          <object class="AdwButtonRow" id="library_button">
-                            <property name="title">Launch Gelly</property>
-                            <property name="sensitive">false</property>
-                            <style>
-                              <class name="suggested-action"/>
-                            </style>
-                          </object>
-                        </child>
-                        <child>
-                          <object class="AdwButtonRow" id="cancel_library_button">
-                            <property name="title">Cancel</property>
-                            <style>
-                              <class name="destructive-action"/>
-                            </style>
-                          </object>
-                        </child>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkButton" id="cancel_library_button">
+                        <property name="label">Cancel</property>
+                        <property name="halign">center</property>
+                        <style>
+                          <class name="destructive-action"/>
+                          <class name="flat"/>
+                        </style>
                       </object>
                     </child>
                   </object>
-                </child>
+                </property>
               </object>
             </child>
           </object>

--- a/resources/ui/song_list.ui
+++ b/resources/ui/song_list.ui
@@ -71,8 +71,6 @@
         </child>
         <child>
           <object class="AdwClamp">
-            <property name="margin-bottom">24</property>
-            <property name="margin-top">24</property>
             <property name="maximum-size">1000</property>
             <child>
               <object class="GtkBox">
@@ -80,6 +78,7 @@
                 <property name="spacing">12</property>
                 <child>
                   <object class="GtkBox">
+                    <property name="margin-top">24</property>
                     <property name="orientation">horizontal</property>
                     <property name="spacing">6</property>
                     <child>

--- a/resources/ui/window.ui
+++ b/resources/ui/window.ui
@@ -31,9 +31,8 @@
                 <property name="sidebar-position">start</property>
                 <property name="sidebar-width-fraction">0.33</property>
                 <property name="content">
-                  <object class="GtkBox" id="player_box">
-                    <property name="orientation">vertical</property>
-                    <child>
+                  <object class="AdwToolbarView" id="player_box">
+                    <property name="content">
                       <object class="GtkStack" id="setup_stack">
                         <child>
                           <object class="GellySetup" id="setup">
@@ -45,13 +44,12 @@
                               <object class="AdwNavigationPage" id="album_detail_page">
                                 <property name="title" translatable="yes">Album Detail</property>
                                 <child>
-                                  <object class="GtkBox">
-                                    <property name="orientation">1</property>
-                                    <child>
+                                  <object class="AdwToolbarView">
+                                    <child type="top">
                                       <object class="AdwHeaderBar">
                                       </object>
                                     </child>
-                                    <child>
+                                    <property name="content">
                                       <object class="GtkScrolledWindow">
                                         <property name="hscrollbar-policy">never</property>
                                         <property name="vscrollbar-policy">automatic</property>
@@ -70,7 +68,7 @@
                                           </object>
                                         </child>
                                       </object>
-                                    </child>
+                                    </property>
                                   </object>
                                 </child>
                               </object>
@@ -79,13 +77,12 @@
                               <object class="AdwNavigationPage" id="artist_detail_page">
                                 <property name="title" translatable="yes">Artist Detail</property>
                                 <child>
-                                  <object class="GtkBox">
-                                    <property name="orientation">1</property>
-                                    <child>
+                                  <object class="AdwToolbarView">
+                                    <child type="top">
                                       <object class="AdwHeaderBar">
                                       </object>
                                     </child>
-                                    <child>
+                                    <property name="content">
                                       <object class="GtkScrolledWindow">
                                         <property name="hscrollbar-policy">never</property>
                                         <property name="vscrollbar-policy">automatic</property>
@@ -103,7 +100,7 @@
                                           </object>
                                         </child>
                                       </object>
-                                    </child>
+                                    </property>
                                   </object>
                                 </child>
                               </object>
@@ -112,13 +109,12 @@
                               <object class="AdwNavigationPage" id="playlist_detail_page">
                                 <property name="title" translatable="yes">Playlist Detail</property>
                                 <child>
-                                  <object class="GtkBox">
-                                    <property name="orientation">1</property>
-                                    <child>
+                                  <object class="AdwToolbarView">
+                                    <child type="top">
                                       <object class="AdwHeaderBar">
                                       </object>
                                     </child>
-                                    <child>
+                                    <property name="content">
                                       <object class="AdwClamp">
                                         <property name="margin-bottom">24</property>
                                         <property name="margin-top">24</property>
@@ -128,7 +124,7 @@
                                           </object>
                                         </child>
                                       </object>
-                                    </child>
+                                    </property>
                                   </object>
                                 </child>
                               </object>
@@ -137,9 +133,8 @@
                               <object class="AdwNavigationPage" id="main_window">
                                 <property name="title" translatable="yes">Main</property>
                                 <child>
-                                  <object class="GtkBox">
-                                    <property name="orientation">1</property>
-                                    <child>
+                                  <object class="AdwToolbarView">
+                                    <child type="top">
                                       <object class="AdwHeaderBar" id="header_bar">
                                         <child type="start">
                                           <object class="GtkToggleButton" id="toggle_queue_button">
@@ -188,7 +183,7 @@
                                         </property>
                                       </object>
                                     </child>
-                                    <child>
+                                    <property name="content">
                                       <object class="AdwViewStack" id="stack">
                                         <property name="vexpand">true</property>
                                         <child>
@@ -240,8 +235,8 @@
                                           </object>
                                         </child>
                                       </object>
-                                    </child>
-                                    <child>
+                                    </property>
+                                    <child type="bottom">
                                       <object class="AdwViewSwitcherBar" id="switcher_bar">
                                         <property name="stack">stack</property>
                                       </object>
@@ -253,17 +248,16 @@
                           </object>
                         </child>
                       </object>
-                    </child>
-                    <child>
+                    </property>
+                    <child type="bottom">
                       <object class="GellyPlayerBar" id="player_bar">
                       </object>
                     </child>
                   </object>
                 </property>
                 <property name="sidebar">
-                  <object class="GtkBox" id="sidebar_box">
-                    <property name="orientation">vertical</property>
-                    <child>
+                  <object class="AdwToolbarView" id="sidebar_box">
+                    <child type="top">
                       <object class="AdwHeaderBar">
                         <property name="show-title">False</property>
                         <child type="start">
@@ -291,10 +285,10 @@
                         </child>
                       </object>
                     </child>
-                    <child>
+                    <property name="content">
                       <object class="GellyQueue" id="queue">
                       </object>
-                    </child>
+                    </property>
                   </object>
                 </property>
               </object>

--- a/src/ui/setup.rs
+++ b/src/ui/setup.rs
@@ -254,13 +254,13 @@ mod imp {
         #[template_child]
         pub password_entry: TemplateChild<adw::PasswordEntryRow>,
         #[template_child]
-        pub connect_button: TemplateChild<adw::ButtonRow>,
+        pub connect_button: TemplateChild<gtk::Button>,
         #[template_child]
         pub library_combo: TemplateChild<adw::ComboRow>,
         #[template_child]
-        pub library_button: TemplateChild<adw::ButtonRow>,
+        pub library_button: TemplateChild<gtk::Button>,
         #[template_child]
-        pub cancel_library_button: TemplateChild<adw::ButtonRow>,
+        pub cancel_library_button: TemplateChild<gtk::Button>,
         pub libraries: RefCell<Vec<LibraryDto>>,
     }
 
@@ -293,7 +293,7 @@ mod imp {
             });
 
             // Setup Connect Button
-            self.connect_button.connect_activated(glib::clone!(
+            self.connect_button.connect_clicked(glib::clone!(
                 #[weak(rename_to=imp)]
                 self,
                 move |_| {
@@ -312,7 +312,7 @@ mod imp {
             ));
 
             // Setup Library Button
-            self.library_button.connect_activated(glib::clone!(
+            self.library_button.connect_clicked(glib::clone!(
                 #[weak(rename_to=imp)]
                 self,
                 move |_| {
@@ -321,7 +321,7 @@ mod imp {
                 }
             ));
 
-            self.cancel_library_button.connect_activated(glib::clone!(
+            self.cancel_library_button.connect_clicked(glib::clone!(
                 #[weak(rename_to=imp)]
                 self,
                 move |_| {


### PR DESCRIPTION
The changes I made are small but I think they solve some small inconsistencies in the UI, moving it closer to other libadwaita applications.

Following are some screenshots demostrating the differences.

Additionally, maybe it would be a good idea to use ListBox instead of ListView for the smaller lists in the app (basically everything but the "Songs" tab). I don't think that it makes a difference for those small lists anyways and it would allow to have a proper boxed-list styling.

<details>
<summary>Screenshots</summary>

<img width="1100" height="892" alt="image" src="https://github.com/user-attachments/assets/136be855-d2f2-4cd3-a6e8-6fef782fe49a" />

<img width="1100" height="892" alt="image" src="https://github.com/user-attachments/assets/79012405-fdae-4751-9755-971355342c39" />

<img width="1100" height="892" alt="image" src="https://github.com/user-attachments/assets/eddd3cb7-73f9-4940-a199-49f0215009de" />

<img width="1100" height="892" alt="image" src="https://github.com/user-attachments/assets/41d34c33-d10c-447d-9412-43375bd1c976" />

<img width="1100" height="892" alt="image" src="https://github.com/user-attachments/assets/75bcf8b1-667a-44f3-8af3-07f5249696a9" />

<img width="555" height="841" alt="image" src="https://github.com/user-attachments/assets/9310604b-2ff9-48f4-9e3a-3ba86f16e973" />

<img width="1100" height="892" alt="image" src="https://github.com/user-attachments/assets/76f6df0b-1ebe-4a91-b8bf-44231c4cfe48" />

</details>