### PR TITLE
feat: search/sort buttons in headerbar toggle search bar and sort bar instead of just showing them

### DIFF
--- a/src/ui/album_list.rs
+++ b/src/ui/album_list.rs
@@ -43,12 +43,20 @@ impl TopPage for AlbumList {
         false
     }
 
-    fn reveal_search_bar(&self, visible: bool) {
-        self.imp().search_bar.set_search_mode(visible);
+    fn toggle_search_bar(&self) {
+        self.toggle_bar(&self.imp().search_bar);
     }
 
-    fn reveal_sort_bar(&self, visible: bool) {
-        self.imp().sort_bar.set_search_mode(visible);
+    fn toggle_sort_bar(&self) {
+        self.toggle_bar(&self.imp().sort_bar);
+    }
+
+    fn hide_search_bar(&self) {
+        self.imp().search_bar.set_search_mode(false);
+    }
+
+    fn hide_sort_bar(&self) {
+        self.imp().sort_bar.set_search_mode(false);
     }
 
     fn play_selected(&self) {

--- a/src/ui/artist_list.rs
+++ b/src/ui/artist_list.rs
@@ -40,12 +40,20 @@ impl TopPage for ArtistList {
         false
     }
 
-    fn reveal_search_bar(&self, visible: bool) {
-        self.imp().search_bar.set_search_mode(visible);
+    fn toggle_search_bar(&self) {
+        self.toggle_bar(&self.imp().search_bar);
     }
 
-    fn reveal_sort_bar(&self, visible: bool) {
-        self.imp().sort_bar.set_search_mode(visible);
+    fn toggle_sort_bar(&self) {
+        self.toggle_bar(&self.imp().sort_bar);
+    }
+
+    fn hide_search_bar(&self) {
+        self.imp().search_bar.set_search_mode(false);
+    }
+
+    fn hide_sort_bar(&self) {
+        self.imp().sort_bar.set_search_mode(false);
     }
 
     fn play_selected(&self) {

--- a/src/ui/page_traits.rs
+++ b/src/ui/page_traits.rs
@@ -23,10 +23,15 @@ pub trait TopPage {
     fn can_search(&self) -> bool;
     fn can_sort(&self) -> bool;
     fn can_new(&self) -> bool;
-    fn reveal_search_bar(&self, visible: bool);
-    fn reveal_sort_bar(&self, visible: bool);
+    fn hide_search_bar(&self);
+    fn hide_sort_bar(&self);
+    fn toggle_search_bar(&self);
+    fn toggle_sort_bar(&self);
     fn play_selected(&self);
     fn create_new(&self) {
         warn!("New not implemented for this type");
+    }
+    fn toggle_bar(&self, bar: &gtk::SearchBar) {
+        bar.set_search_mode(!bar.is_search_mode());
     }
 }

--- a/src/ui/playlist_list.rs
+++ b/src/ui/playlist_list.rs
@@ -49,12 +49,20 @@ impl TopPage for PlaylistList {
         true
     }
 
-    fn reveal_search_bar(&self, visible: bool) {
-        self.imp().search_bar.set_search_mode(visible);
+    fn toggle_search_bar(&self) {
+        self.toggle_bar(&self.imp().search_bar);
     }
 
-    fn reveal_sort_bar(&self, visible: bool) {
-        self.imp().sort_bar.set_search_mode(visible);
+    fn toggle_sort_bar(&self) {
+        self.toggle_bar(&self.imp().sort_bar);
+    }
+
+    fn hide_search_bar(&self) {
+        self.imp().search_bar.set_search_mode(false);
+    }
+
+    fn hide_sort_bar(&self) {
+        self.imp().sort_bar.set_search_mode(false);
     }
 
     fn play_selected(&self) {

--- a/src/ui/queue.rs
+++ b/src/ui/queue.rs
@@ -32,8 +32,10 @@ impl TopPage for Queue {
         false
     }
 
-    fn reveal_search_bar(&self, _visible: bool) {}
-    fn reveal_sort_bar(&self, _visible: bool) {}
+    fn toggle_search_bar(&self) {}
+    fn toggle_sort_bar(&self) {}
+    fn hide_search_bar(&self) {}
+    fn hide_sort_bar(&self) {}
     fn play_selected(&self) {}
 }
 

--- a/src/ui/song_list.rs
+++ b/src/ui/song_list.rs
@@ -48,12 +48,20 @@ impl TopPage for SongList {
         false
     }
 
-    fn reveal_search_bar(&self, visible: bool) {
-        self.imp().search_bar.set_search_mode(visible);
+    fn toggle_search_bar(&self) {
+        self.toggle_bar(&self.imp().search_bar);
     }
 
-    fn reveal_sort_bar(&self, visible: bool) {
-        self.imp().sort_bar.set_search_mode(visible);
+    fn toggle_sort_bar(&self) {
+        self.toggle_bar(&self.imp().sort_bar);
+    }
+
+    fn hide_search_bar(&self) {
+        self.imp().search_bar.set_search_mode(false);
+    }
+
+    fn hide_sort_bar(&self) {
+        self.imp().sort_bar.set_search_mode(false);
     }
 
     fn play_selected(&self) {

--- a/src/ui/window.rs
+++ b/src/ui/window.rs
@@ -392,8 +392,8 @@ mod imp {
                     self,
                     move |_, _, _| {
                         window.obj().call_on_visible_page(|page| {
-                            page.reveal_search_bar(true);
-                            page.reveal_sort_bar(false);
+                            page.toggle_search_bar();
+                            page.hide_sort_bar();
                         });
                     }
                 ))
@@ -405,8 +405,8 @@ mod imp {
                     self,
                     move |_, _, _| {
                         window.obj().call_on_visible_page(|page| {
-                            page.reveal_search_bar(false);
-                            page.reveal_sort_bar(true);
+                            page.hide_search_bar();
+                            page.toggle_sort_bar();
                         });
                     }
                 ))


### PR DESCRIPTION
This is a fairly small change that fixes an annoyance I have with these two bars: normally in other applications (gnome-control-center is an easy example) the buttons to activate search mode are toggles, but in Gelly they are show-only buttons, requiring a button press on the "x" button in the searchbar to dismiss them.