### PR TITLE
fix: remove "Main" title when window is small

### DIFF
--- a/resources/ui/window.ui
+++ b/resources/ui/window.ui
@@ -131,7 +131,6 @@
                             </child>
                             <child>
                               <object class="AdwNavigationPage" id="main_window">
-                                <property name="title" translatable="yes">Main</property>
                                 <child>
                                   <object class="AdwToolbarView">
                                     <child type="top">


### PR DESCRIPTION
This is really quite simple, when the window is small enough to hide the stack switcher to the bottom, the main window title shows "Main", which I think is not desired.

Here's the difference:

| Before | After |
|---|---|
| <img width="503" height="914" alt="image" src="https://github.com/user-attachments/assets/de52435f-01ec-4ebd-8bae-b1d64cdf4e94" /> | <img width="503" height="914" alt="image" src="https://github.com/user-attachments/assets/b41f836c-5f55-4368-868b-d4ed2724df3b" /> |