### PR TITLE
fix: remove bottom margin from playlist details page

### DIFF
--- a/resources/ui/window.ui
+++ b/resources/ui/window.ui
@@ -116,7 +116,6 @@
                                     </child>
                                     <property name="content">
                                       <object class="AdwClamp">
-                                        <property name="margin-bottom">24</property>
                                         <property name="margin-top">24</property>
                                         <property name="maximum-size">1000</property>
                                         <child>


### PR DESCRIPTION
Another simple one, here I missed the bottom margin in the playlist details page. This change removes the bottom margin, bringing the look in line with the updated song list UI