### PR TITLE
fix: sidebar reveal on breakpoint

### DIFF
--- a/resources/ui/window.ui
+++ b/resources/ui/window.ui
@@ -6,7 +6,6 @@
     <child>
       <object class="AdwBreakpoint" id="sidebar_breakpoint">
         <condition>max-width: 800sp</condition>
-        <setter object="split_view" property="collapsed">True</setter>
       </object>
     </child>
     <child>
@@ -14,7 +13,6 @@
         <condition>max-width: 550sp</condition>
         <setter object="header_bar" property="title-widget"></setter>
         <setter object="switcher_bar" property="reveal">true</setter>
-        <setter object="split_view" property="collapsed">True</setter>
       </object>
     </child>
     <property name="content">

--- a/src/ui/window.rs
+++ b/src/ui/window.rs
@@ -312,6 +312,10 @@ mod imp {
         pub split_view: TemplateChild<adw::OverlaySplitView>,
         #[template_child]
         pub bottom_sheet: TemplateChild<adw::BottomSheet>,
+        #[template_child]
+        pub breakpoint: TemplateChild<adw::Breakpoint>,
+        #[template_child]
+        pub sidebar_breakpoint: TemplateChild<adw::Breakpoint>,
     }
 
     #[glib::object_subclass]
@@ -631,6 +635,24 @@ mod imp {
                     app.refresh_all(config::get_refresh_on_startup());
                 }
             ));
+
+            {
+                let breakpoint_fn = move |collapse: bool| {
+                    clone!(
+                        #[weak(rename_to = split_view)]
+                        self.split_view,
+                        move |_: &adw::Breakpoint| {
+                            let sidebar_open = split_view.shows_sidebar();
+                            split_view.set_collapsed(collapse);
+                            split_view.set_show_sidebar(sidebar_open);
+                        }
+                    )
+                };
+                for breakpoint in [&self.breakpoint, &self.sidebar_breakpoint] {
+                    breakpoint.connect_apply(breakpoint_fn(true));
+                    breakpoint.connect_unapply(breakpoint_fn(false));
+                }
+            }
 
             let update_margin = clone!(
                 #[weak(rename_to = main)]


### PR DESCRIPTION
## IMPORTANT

This PR depends on #69 since it uses the two breakpoints. The reason I didn't base it on main is because I would have had to remake it from scratch, assuming the other PR gets merged.

The diff will show the changes from the other PR as well, so just look at the last commit for the actual change.

---

The new behavior as of this PR is that the last sidebar state is preserved, so if the breakpoint(s) activate/deactivate with the sidebar open, it stays open. Similarly if closed, it will stay closed.

It might be desirable to always close the sidebar when the view collapses, but I leave the decision up to you.