### PR TITLE
fix: limit window min height to avoid cropping the bottom sheet

### DIFF
--- a/resources/ui/window.ui
+++ b/resources/ui/window.ui
@@ -3,6 +3,7 @@
   <requires lib="gtk" version="4.0"/>
   <template class="GellyApplicationWindow" parent="AdwApplicationWindow">
     <property name="title">Gelly</property>
+    <property name="height-request">500</property>
     <child>
       <object class="AdwBreakpoint" id="sidebar_breakpoint">
         <condition>max-width: 800sp</condition>


### PR DESCRIPTION
Before the change you can resize the window below a reasonable point, resulting in an undesirable cropping of the bottom sheet:

<img width="410" height="250" alt="image" src="https://github.com/user-attachments/assets/72b9fd78-9469-424d-b0fe-441fe12e5208" />

After this change, the height is limited to this:

<img width="410" height="550" alt="image" src="https://github.com/user-attachments/assets/c8b6b1a0-75d5-47c5-9f3d-a089118ade71" />


