### PR TITLE
feat: restyle album art; fix error icon size

### DIFF
--- a/resources/style.css
+++ b/resources/style.css
@@ -16,10 +16,6 @@
     min-height: 0;
 }
 
-.album-image-frame {
-    border-radius: 12px;
-}
-
 progressbar.osd {
     margin-top: 3em;
 }

--- a/resources/ui/album_art.ui
+++ b/resources/ui/album_art.ui
@@ -3,22 +3,19 @@
   <requires lib="gtk" version="4.0"/>
   <template class="GellyAlbumArt" parent="GtkBox">
     <property name="halign">center</property>
-		<property name="margin-start">6</property>
+    <property name="margin-start">6</property>
     <property name="margin-end">6</property>
     <property name="margin-top">6</property>
     <property name="margin-bottom">6</property>
     <property name="orientation">vertical</property>
+    <property name="overflow">hidden</property>
+    <style>
+      <class name="card"/>
+    </style>
     <child>
       <object class="GtkOverlay">
         <child>
-          <object class="GtkFrame" id="image_frame">
-            <style>
-              <class name="album-image-frame"/>
-            </style>
-            <property name="child">
-              <object class="GtkImage" id="album_image">
-              </object>
-            </property>
+          <object class="GtkImage" id="album_image">
           </object>
         </child>
         <child type="overlay">
@@ -35,7 +32,6 @@
           <object class="GtkImage" id="error_icon">
             <property name="tooltip-text" translatable="yes">Missing album art</property>
             <property name="icon-name">audio-x-generic-symbolic</property>
-            <property name="pixel-size">100</property>
             <property name="halign">center</property>
             <property name="valign">center</property>
             <property name="visible">false</property>

--- a/src/ui/album_art.rs
+++ b/src/ui/album_art.rs
@@ -183,6 +183,11 @@ mod imp {
                 widget.load_image();
             });
 
+            self.obj()
+                .bind_property("size", &self.error_icon.get(), "pixel-size")
+                .transform_to(move |_, size: u32| Some(((size as f32 * 0.4) as i32).max(1)))
+                .sync_create()
+                .build();
             // Bind the width and height properties to the picture widget
             self.obj()
                 .bind_property("size", &self.album_image.get(), "pixel-size")


### PR DESCRIPTION
A quick bullet list to explain the changes:

- Make the error icon size always 40% the size of the album art widget
- Remove the gtk frame
- Remove the custom css, use the "card" style class built into libadwaita instead

I'll also leave a comment in a piece of code that might require a bit of an explanation

<img width="979" height="105" alt="Screenshot_20260402_184723" src="https://github.com/user-attachments/assets/05893757-fdfe-440e-98f3-f433121d7180" />

<img width="485" height="56" alt="Screenshot_20260402_184744" src="https://github.com/user-attachments/assets/131459be-0d56-452a-9efa-fcb7e1148c04" />

<img width="1032" height="1064" alt="Screenshot_20260402_184648" src="https://github.com/user-attachments/assets/b9b264b0-e5ce-420e-9bfd-783bf128f3eb" />

<img width="1032" height="1064" alt="Screenshot_20260402_184630" src="https://github.com/user-attachments/assets/5bfd5607-44e8-40a4-adef-8b1fbd4863b1" />
