### PR TITLE
fix: big player blur background crop; remove max size for title in big player

### DIFF
--- a/resources/ui/player_bar/big_player.ui
+++ b/resources/ui/player_bar/big_player.ui
@@ -1,31 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <interface>
   <requires lib="gtk" version="4.0"/>
-  <template class="GellyBigPlayer" parent="GtkBox">
-    <property name="orientation">vertical</property>
-    <property name="visible">true</property>
-    <property name="spacing">6</property>
-    <property name="margin-start">6</property>
-    <property name="margin-end">6</property>
-    <property name="margin-top">48</property>
-    <property name="margin-bottom">6</property>
-    <child>
-      <!-- Song info section -->
-      <object class="GtkBox">
-        <property name="halign">center</property>
-        <child>
-          <object class="GellyAlbumArt" id="album_art">
-            <property name="size">256</property>
-          </object>
-        </child>
-      </object>
-    </child>
+  <template class="GellyBigPlayer" parent="AdwBin">
     <child>
       <object class="GtkBox">
         <property name="orientation">vertical</property>
         <property name="spacing">6</property>
         <property name="valign">center</property>
         <property name="hexpand">true</property>
+        <property name="margin-top">48</property>
+        <property name="margin-start">6</property>
+        <property name="margin-end">6</property>
+        <property name="margin-bottom">6</property>
         <child>
           <object class="GtkBox">
             <property name="orientation">vertical</property>
@@ -33,10 +19,16 @@
             <property name="valign">center</property>
             <property name="hexpand">true</property>
             <child>
+              <object class="GellyAlbumArt" id="album_art">
+                <property name="size">256</property>
+              </object>
+            </child>
+            <child>
               <object class="GtkLabel" id="title_label">
                 <property name="halign">center</property>
                 <property name="ellipsize">end</property>
-                <property name="max-width-chars">30</property>
+                <property name="margin-start">12</property>
+                <property name="margin-end">12</property>
                 <style>
                   <class name="heading"/>
                 </style>

--- a/src/ui/player_bar/big_player.rs
+++ b/src/ui/player_bar/big_player.rs
@@ -6,7 +6,7 @@ use log::debug;
 
 glib::wrapper! {
     pub struct BigPlayer(ObjectSubclass<imp::BigPlayer>)
-    @extends gtk::Widget, gtk::Box,
+    @extends gtk::Widget, adw::Bin,
         @implements gio::ActionMap, gio::ActionGroup, gtk::Accessible, gtk::Buildable, gtk::ConstraintTarget;
 }
 
@@ -169,7 +169,7 @@ mod imp {
     impl ObjectSubclass for BigPlayer {
         const NAME: &'static str = "GellyBigPlayer";
         type Type = super::BigPlayer;
-        type ParentType = gtk::Box;
+        type ParentType = adw::Bin;
 
         fn class_init(klass: &mut Self::Class) {
             klass.bind_template();
@@ -202,7 +202,7 @@ mod imp {
         }
     }
 
-    impl BoxImpl for BigPlayer {}
+    impl BinImpl for BigPlayer {}
     impl WidgetImpl for BigPlayer {
         fn snapshot(&self, snapshot: &gtk::Snapshot) {
             self.snapshot_background(snapshot);


### PR DESCRIPTION
two small changes:

1. there is a very easy to miss gap in the background blur in the big player; this is caused by the big player having a margin of its own, instead of its children. I removed the margin from itself, made it a bin while I was at it and removed a superfluous box child

### Before

<img width="916" height="1074" alt="image" src="https://github.com/user-attachments/assets/4a6c9a1e-3123-4db8-8a2f-f44c9b7ee243" />

### After

<img width="916" height="1074" alt="Screenshot_20260403_134929" src="https://github.com/user-attachments/assets/e3ef657b-2514-4062-8662-7626b21c1661" />

---

2. I removed the superfluous 30 character limit for the title in the big player, so that all the width can be used for it:

### Before

<img width="916" height="1074" alt="Screenshot_20260403_135058" src="https://github.com/user-attachments/assets/6f24a15a-e33e-4dc1-81d0-180b442f9d79" />

### After

<img width="916" height="1074" alt="Screenshot_20260403_135029" src="https://github.com/user-attachments/assets/530b5911-097d-47ed-813c-2bd2f955972b" />
