### PR TITLE
Enable audio normalization for subsonic backend

### DIFF
--- a/resources/ui/preferences.ui
+++ b/resources/ui/preferences.ui
@@ -37,7 +37,7 @@
             <child>
               <object class="AdwActionRow">
                 <property name="title" translatable="yes">Normalize Audio</property>
-                <property name="subtitle" translatable="yes">Not supported on Subsonic backends.</property>
+                <property name="subtitle" translatable="yes">May require backend plugins.</property>
                 <property name="use_underline">True</property>
                 <property name="activatable_widget">normalize_audio_switch</property>
                 <child>

--- a/src/config.rs
+++ b/src/config.rs
@@ -270,7 +270,7 @@ pub fn get_playlist_most_played_enabled() -> bool {
 }
 
 pub fn get_normalize_audio_enabled() -> bool {
-    settings().boolean("normalize-audio") && get_backend_type() != BackendType::Subsonic
+    settings().boolean("normalize-audio")
 }
 
 pub fn get_inhibit_suspend_enabled() -> bool {

--- a/src/subsonic/api.rs
+++ b/src/subsonic/api.rs
@@ -141,6 +141,7 @@ pub struct Song {
     pub bit_rate: Option<u64>,
     pub sampling_rate: Option<u64>,
     pub channel_count: Option<u32>,
+    pub replay_gain: Option<ReplayGain>,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -188,4 +189,12 @@ pub struct StructuredLyrics {
 pub struct LyricLine {
     pub value: String,
     pub start: Option<u64>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ReplayGain {
+    pub track_gain: Option<f64>,
+    pub album_gain: Option<f64>,
+    pub base_gain: Option<f64>,
 }

--- a/src/subsonic/mod.rs
+++ b/src/subsonic/mod.rs
@@ -234,6 +234,10 @@ impl Subsonic {
         let date_created = song.created.or_else(|| fallback.created.clone());
         let production_year = song.year.or(fallback.year);
 
+        let normalization_gain = song
+            .replay_gain
+            .and_then(|rg| rg.track_gain.or(rg.album_gain).or(rg.base_gain));
+
         MusicDto {
             name: song.title,
             id: song.id,
@@ -245,7 +249,7 @@ impl Subsonic {
                 id: artist_id,
             }],
             album_id,
-            normalization_gain: None,
+            normalization_gain,
             production_year,
             index_number: song.track,
             parent_index_number: song.disc_number,


### PR DESCRIPTION
Enables replay gain normalization if available, though it looks like Navidrome at least doesn't calculate these values by default, requiring a plugin to do it instead.