### PR TITLE
Add "Show Album Artists Only" setting for Artists tab

### DIFF
--- a/resources/io.m51.Gelly.gschema.xml
+++ b/resources/io.m51.Gelly.gschema.xml
@@ -81,6 +81,10 @@
       <default>0</default>
       <summary>Sort artists direction</summary>
     </key>
+    <key name="artists-show-only-album-artists" type="b">
+      <default>true</default>
+      <summary>Show only album artists in the Artists tab</summary>
+    </key>
     <key name="sort-playlists-by" type="u">
       <default>0</default>
       <summary>Sort playlists by</summary>

--- a/resources/ui/preferences.ui
+++ b/resources/ui/preferences.ui
@@ -11,6 +11,12 @@
           <object class="AdwPreferencesGroup">
             <property name="title" translatable="yes">General</property>
             <child>
+              <object class="AdwSwitchRow" id="artists_show_only_album_artists_row">
+                <property name="title" translatable="yes">Show Album Artists Only</property>
+                <property name="subtitle" translatable="yes">Only show album artists in the Artists tab. Disable to also show track/featured artists. Requires a library refresh to take effect.</property>
+              </object>
+            </child>
+            <child>
               <object class="AdwActionRow">
                 <property name="title" translatable="yes">Refresh library on startup</property>
                 <property name="subtitle" translatable="yes">The library can be refreshed using ctrl+r or the menu.</property>

--- a/src/config.rs
+++ b/src/config.rs
@@ -331,3 +331,7 @@ pub fn set_playlists_sort_direction(direction: u32) {
         .set_uint("sort-playlists-direction", direction)
         .unwrap();
 }
+
+pub fn get_artists_show_only_album_artists() -> bool {
+    settings().boolean("artists-show-only-album-artists")
+}

--- a/src/jellyfin/api.rs
+++ b/src/jellyfin/api.rs
@@ -68,6 +68,12 @@ pub struct MusicDto {
     pub run_time_ticks: u64,
     pub album: Option<String>,
     pub album_artists: Vec<ArtistItemsDto>,
+    #[serde(
+        default,
+        rename = "ArtistItems",
+        deserialize_with = "deserialize_items_skip_errors"
+    )]
+    pub song_artists: Vec<ArtistItemsDto>,
     pub album_id: Option<String>,
     pub normalization_gain: Option<f64>,
     pub production_year: Option<u32>,

--- a/src/library_utils.rs
+++ b/src/library_utils.rs
@@ -1,6 +1,6 @@
 use crate::application::Application;
 use crate::backend::BackendError;
-use crate::jellyfin::api::MusicDto;
+use crate::jellyfin::api::{ArtistItemsDto, MusicDto};
 use crate::models::{AlbumModel, ArtistModel, PlaylistModel, SongModel};
 use rand::prelude::*;
 use std::collections::{HashMap, HashSet};
@@ -31,24 +31,42 @@ pub fn albums_from_library(library: &[MusicDto]) -> Vec<AlbumModel> {
     albums
 }
 
-pub fn artists_from_library(library: &[MusicDto]) -> Vec<ArtistModel> {
+pub fn artists_from_library(library: &[MusicDto], only_album_artists: bool) -> Vec<ArtistModel> {
     let mut play_count_map = HashMap::<String, u64>::new();
     for dto in library {
         for artist in &dto.album_artists {
             *play_count_map.entry(artist.id.clone()).or_insert(0) += dto.user_data.play_count;
         }
-    }
-    let mut seen_artist_ids = HashSet::new();
-    let mut artists: Vec<ArtistModel> = library
-        .iter()
-        .flat_map(|dto| &dto.album_artists)
-        .filter(|artist| seen_artist_ids.insert(&artist.id))
-        .map(|dto| {
-            let artist = ArtistModel::from(dto);
-            if let Some(&total_play_count) = play_count_map.get(&dto.id) {
-                artist.set_play_count(total_play_count);
+        if !only_album_artists {
+            for artist in &dto.song_artists {
+                *play_count_map.entry(artist.id.clone()).or_insert(0) += dto.user_data.play_count;
             }
-            artist
+        }
+    }
+
+    let all_artists: Vec<ArtistItemsDto> = library
+        .iter()
+        .flat_map(|dto| {
+            if only_album_artists {
+                dto.album_artists.to_vec()
+            } else {
+                let mut v = dto.album_artists.to_vec();
+                v.extend_from_slice(&dto.song_artists);
+                v
+            }
+        })
+        .collect();
+
+    let mut seen_artist_ids = HashSet::<String>::new();
+    let mut artists: Vec<ArtistModel> = all_artists
+        .iter()
+        .filter(|artist| seen_artist_ids.insert(artist.id.clone()))
+        .map(|artist| {
+            let model = ArtistModel::from(artist);
+            if let Some(&total_play_count) = play_count_map.get(&artist.id) {
+                model.set_play_count(total_play_count);
+            }
+            model
         })
         .collect();
     artists.sort_by_key(|artist| artist.name().to_lowercase());
@@ -186,6 +204,7 @@ mod tests {
                 name: artist_name.to_string(),
                 id: artist_id.to_string(),
             }],
+            song_artists: vec![],
             date_created: Some("2025-01-01".to_string()),
             run_time_ticks: 2000000000, // ~3 minutes
             normalization_gain: None,
@@ -218,6 +237,7 @@ mod tests {
             album: Some(album.to_string()),
             album_id: Some(album_id.to_string()),
             album_artists,
+            song_artists: vec![],
             date_created: Some("2025-01-01".to_string()),
             run_time_ticks: 2000000000,
             normalization_gain: None,
@@ -240,6 +260,7 @@ mod tests {
                 name: format!("user-data-{}", play_count),
                 id: format!("user-data-{}", play_count),
             }],
+            song_artists: vec![],
             date_created: Some("2025-01-01".to_string()),
             run_time_ticks: 2000000000,
             normalization_gain: None,
@@ -342,7 +363,7 @@ mod tests {
             ), // Duplicate artist
         ];
 
-        let artists = artists_from_library(&library);
+        let artists = artists_from_library(&library, true);
 
         assert_eq!(artists.len(), 2);
         assert_eq!(artists[0].name(), "Alpha Artist");
@@ -384,7 +405,7 @@ mod tests {
             ),
         ];
 
-        let artists = artists_from_library(&library);
+        let artists = artists_from_library(&library, true);
 
         assert_eq!(artists.len(), 3);
         assert_eq!(artists[0].name(), "Alpha");
@@ -414,7 +435,7 @@ mod tests {
             ),
         ];
 
-        let artists = artists_from_library(&library);
+        let artists = artists_from_library(&library, true);
 
         assert_eq!(artists.len(), 2);
         assert_eq!(artists[0].name(), "Artist A");

--- a/src/subsonic/api.rs
+++ b/src/subsonic/api.rs
@@ -107,6 +107,14 @@ pub struct AlbumListEntry {
 
 #[derive(Debug, Clone, Deserialize)]
 #[serde(rename_all = "camelCase")]
+pub struct ArtistRef {
+    #[serde(deserialize_with = "deserialize_id_string")]
+    pub id: String,
+    pub name: String,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct Album {
     pub id: String,
     pub name: String,
@@ -114,6 +122,9 @@ pub struct Album {
     pub artist_id: Option<String>,
     pub created: Option<String>,
     pub year: Option<u32>,
+
+    #[serde(default, deserialize_with = "deserialize_items_skip_errors")]
+    pub album_artists: Vec<ArtistRef>,
 
     #[serde(default, deserialize_with = "deserialize_items_skip_errors")]
     pub song: Vec<Song>,
@@ -130,6 +141,10 @@ pub struct Song {
     pub artist: Option<String>,
     pub artist_id: Option<String>,
     pub album_artist: Option<String>,
+    #[serde(default, deserialize_with = "deserialize_items_skip_errors")]
+    pub album_artists: Vec<ArtistRef>,
+    #[serde(default, deserialize_with = "deserialize_items_skip_errors")]
+    pub artists: Vec<ArtistRef>,
     pub duration: Option<u64>,
     pub track: Option<u32>,
     pub disc_number: Option<u32>,

--- a/src/subsonic/mod.rs
+++ b/src/subsonic/mod.rs
@@ -10,7 +10,7 @@ use crate::jellyfin::api::{
     MediaStream, MusicDto, MusicDtoList, PlaybackInfo, PlaybackReport, PlaybackReportStatus,
     PlaylistDtoList, PlaylistItems, UserDataDto,
 };
-use crate::subsonic::api::{Song, SubsonicEnvelope, SubsonicResponse};
+use crate::subsonic::api::{ArtistRef, Song, SubsonicEnvelope, SubsonicResponse};
 
 pub mod api;
 
@@ -32,6 +32,7 @@ struct AlbumFallback {
     album_name: Option<String>,
     artist_name: Option<String>,
     artist_id: Option<String>,
+    album_artists: Vec<ArtistRef>,
     year: Option<u32>,
     created: Option<String>,
 }
@@ -201,6 +202,7 @@ impl Subsonic {
             album_name: Some(album.name.clone()),
             artist_name: album.artist.clone(),
             artist_id: album.artist_id.clone(),
+            album_artists: album.album_artists,
             year: album.year,
             created: album.created.clone(),
         };
@@ -218,16 +220,59 @@ impl Subsonic {
         let album = song.album.or_else(|| fallback.album_name.clone());
         let album_id = song.album_id.or_else(|| fallback.album_id.clone());
 
-        let artist_name = song
-            .album_artist
-            .or(song.artist)
-            .or(fallback.artist_name.clone())
-            .unwrap_or_else(|| "Unknown Artist".to_string());
+        let album_artists: Vec<ArtistItemsDto> = if !song.album_artists.is_empty() {
+            song.album_artists
+                .into_iter()
+                .map(|a| ArtistItemsDto {
+                    name: a.name,
+                    id: a.id,
+                })
+                .collect()
+        } else if !fallback.album_artists.is_empty() {
+            fallback
+                .album_artists
+                .iter()
+                .map(|a| ArtistItemsDto {
+                    name: a.name.clone(),
+                    id: a.id.clone(),
+                })
+                .collect()
+        } else {
+            let artist_name = song
+                .album_artist
+                .as_deref()
+                .or(song.artist.as_deref())
+                .or(fallback.artist_name.as_deref())
+                .unwrap_or("Unknown Artist")
+                .to_string();
+            let artist_id = song
+                .artist_id
+                .clone()
+                .or(fallback.artist_id.clone())
+                .unwrap_or_default();
+            vec![ArtistItemsDto {
+                name: artist_name,
+                id: artist_id,
+            }]
+        };
 
-        let artist_id = song
-            .artist_id
-            .or(fallback.artist_id.clone())
-            .unwrap_or_default();
+        let song_artists: Vec<ArtistItemsDto> = if !song.artists.is_empty() {
+            song.artists
+                .into_iter()
+                .map(|a| ArtistItemsDto {
+                    name: a.name,
+                    id: a.id,
+                })
+                .collect()
+        } else if let Some(name) = song.artist {
+            let id = song
+                .artist_id
+                .or(fallback.artist_id.clone())
+                .unwrap_or_default();
+            vec![ArtistItemsDto { name, id }]
+        } else {
+            vec![]
+        };
 
         let duration_ticks = song.duration.unwrap_or(0).saturating_mul(10_000_000);
 
@@ -244,10 +289,8 @@ impl Subsonic {
             date_created,
             run_time_ticks: duration_ticks,
             album,
-            album_artists: vec![ArtistItemsDto {
-                name: artist_name,
-                id: artist_id,
-            }],
+            album_artists,
+            song_artists,
             album_id,
             normalization_gain,
             production_year,
@@ -315,6 +358,7 @@ impl Subsonic {
             album_name: None,
             artist_name: None,
             artist_id: None,
+            album_artists: vec![],
             year: None,
             created: None,
         };

--- a/src/ui/artist_list.rs
+++ b/src/ui/artist_list.rs
@@ -90,7 +90,10 @@ impl ArtistList {
 
     pub fn pull_artists(&self) {
         let library = self.get_application().library().clone();
-        let artists = artists_from_library(&library.borrow());
+        let artists = artists_from_library(
+            &library.borrow(),
+            config::get_artists_show_only_album_artists(),
+        );
         if artists.is_empty() {
             self.set_empty(true);
         } else {

--- a/src/ui/preferences.rs
+++ b/src/ui/preferences.rs
@@ -70,6 +70,14 @@ impl Preferences {
             )
             .build();
 
+        settings
+            .bind(
+                "artists-show-only-album-artists",
+                &*imp.artists_show_only_album_artists_row,
+                "active",
+            )
+            .build();
+
         // Transcoding Profile
         imp.transcoding_profile_row
             .set_model(Some(&TranscodingProfile::as_string_list()));
@@ -121,6 +129,8 @@ mod imp {
         pub playlist_most_played_enabled_switch: TemplateChild<gtk::Switch>,
         #[template_child]
         pub album_art_background_row: TemplateChild<adw::SwitchRow>,
+        #[template_child]
+        pub artists_show_only_album_artists_row: TemplateChild<adw::SwitchRow>,
     }
 
     #[glib::object_subclass]


### PR DESCRIPTION
## Summary

- Adds a **"Show Album Artists Only"** toggle in Preferences → General (default: on, no change in existing behaviour). When disabled, the Artists tab also shows track/featured artists alongside album artists. Requires a library refresh to take effect.
- For OpenSubsonic-compatible backends (e.g. Navidrome), parses the extended `albumArtists` and `artists` arrays on songs and albums. This gives album artists proper IDs rather than falling back to the track artist ID, preventing duplicate/mismatched entries when songs have featured artists.

Suggestion for resolving #100

## Test plan

- [ ] Enable the setting (default) — Artists tab shows album artists only, same as before
- [ ] Disable the setting — Artists tab also shows track/featured artists after a library refresh
- [ ] Tested on Navidrome; basic Subsonic behaviour unchanged by default