### PR TITLE
fix: prefer track artist over album artist for individual songs

### DIFF
--- a/src/subsonic/mod.rs
+++ b/src/subsonic/mod.rs
@@ -274,29 +274,39 @@ impl Subsonic {
         let album = song.album.or_else(|| fallback.album_name.clone());
         let album_id = song.album_id.or_else(|| fallback.album_id.clone());
 
-        // The opensubsonic API is disgusting
+        // Prefer the track-level artist (song.artist / song.artist_id) over the
+        // album artist so that compilation tracks show the correct performer.
+        // Fall back to album_artists / album_artist when no track artist is set.
         let artist_name = song
-            .album_artists
-            .first()
-            .map(|artist| artist.name.clone())
-            .or(fallback
-                .album_artists
-                .first()
-                .map(|artist| artist.name.clone()))
+            .artist
             .or(song.album_artist)
-            .or(song.artist)
+            .or_else(|| {
+                song.album_artists
+                    .first()
+                    .map(|artist| artist.name.clone())
+            })
+            .or_else(|| {
+                fallback
+                    .album_artists
+                    .first()
+                    .map(|artist| artist.name.clone())
+            })
             .or(fallback.artist_name.clone())
             .unwrap_or_else(|| "Unknown Artist".to_string());
 
         let artist_id = song
-            .album_artists
-            .first()
-            .map(|artist| artist.id.clone())
-            .or(fallback
-                .album_artists
-                .first()
-                .map(|artist| artist.id.clone()))
-            .or(song.artist_id)
+            .artist_id
+            .or_else(|| {
+                song.album_artists
+                    .first()
+                    .map(|artist| artist.id.clone())
+            })
+            .or_else(|| {
+                fallback
+                    .album_artists
+                    .first()
+                    .map(|artist| artist.id.clone())
+            })
             .or(fallback.artist_id.clone())
             .unwrap_or_default();
 


### PR DESCRIPTION
## Problem

Closes #116.

`song_to_music_dto` resolved the display artist by checking `song.album_artists` first. For compilation albums — where `album_artist` is "Various Artists" — every track showed "Various Artists" instead of the actual performer. The bug also affected the MPRIS metadata that media players and desktop environments read.

## Root cause

```rust
// Before — album_artists checked FIRST
let artist_name = song
    .album_artists.first().map(|a| a.name.clone())   // "Various Artists" ← wins
    .or(fallback.album_artists.first().map(...))
    .or(song.album_artist)
    .or(song.artist)    // "PSYQUI" ← never reached
    ...
```

## Fix

Reorder the chain to prefer the track-level artist:

```rust
// After — song.artist checked FIRST
let artist_name = song
    .artist                                           // "PSYQUI" ← correct
    .or(song.album_artist)
    .or_else(|| song.album_artists.first().map(...))  // "Various Artists" ← fallback
    ...
```

Same reordering applied to `artist_id` so the name and ID remain consistent.

Since `MusicDto.album_artists` stores the resolved artist name, both the UI label and MPRIS metadata now show the correct per-track performer.