### PR TITLE
i18n: add more translatable strings

### DIFF
--- a/po/gelly.pot
+++ b/po/gelly.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-04 12:54+0200\n"
+"POT-Creation-Date: 2026-06-04 16:03-0700\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -138,80 +138,80 @@ msgstr ""
 msgid "No"
 msgstr ""
 
-#: src/ui/stream_info_dialog.rs:21 src/ui/stream_info_dialog.rs:29
-#: src/ui/stream_info_dialog.rs:51
+#: src/ui/stream_info_dialog.rs:21 src/ui/stream_info_dialog.rs:32
+#: src/ui/stream_info_dialog.rs:54
 msgid "Unknown"
 msgstr ""
 
-#: src/ui/stream_info_dialog.rs:28
+#: src/ui/stream_info_dialog.rs:29
 msgid "Backend"
 msgstr ""
 
-#: src/ui/stream_info_dialog.rs:29
+#: src/ui/stream_info_dialog.rs:32
 msgid "Codec"
 msgstr ""
 
-#: src/ui/stream_info_dialog.rs:31
+#: src/ui/stream_info_dialog.rs:34
 msgid "Container"
 msgstr ""
 
-#: src/ui/stream_info_dialog.rs:32 src/ui/stream_info_dialog.rs:55
+#: src/ui/stream_info_dialog.rs:35 src/ui/stream_info_dialog.rs:58
 msgid "None"
 msgstr ""
 
-#: src/ui/stream_info_dialog.rs:35
+#: src/ui/stream_info_dialog.rs:38
 msgid "Sample Rate"
 msgstr ""
 
-#: src/ui/stream_info_dialog.rs:38
+#: src/ui/stream_info_dialog.rs:41
 msgid "Channels"
 msgstr ""
 
-#: src/ui/stream_info_dialog.rs:41
+#: src/ui/stream_info_dialog.rs:44
 msgid "Bit Rate"
 msgstr ""
 
-#: src/ui/stream_info_dialog.rs:44
+#: src/ui/stream_info_dialog.rs:47
 msgid "Encoder"
 msgstr ""
 
-#: src/ui/stream_info_dialog.rs:50
+#: src/ui/stream_info_dialog.rs:53
 msgid "Original Codec"
 msgstr ""
 
-#: src/ui/stream_info_dialog.rs:54
+#: src/ui/stream_info_dialog.rs:57
 msgid "Original Container"
 msgstr ""
 
-#: src/ui/stream_info_dialog.rs:58
+#: src/ui/stream_info_dialog.rs:61
 msgid "Original Sample Rate"
 msgstr ""
 
-#: src/ui/stream_info_dialog.rs:62
+#: src/ui/stream_info_dialog.rs:65
 msgid "Original Channels"
 msgstr ""
 
-#: src/ui/stream_info_dialog.rs:65
+#: src/ui/stream_info_dialog.rs:69
 msgid "Supports Direct Play"
 msgstr ""
 
-#: src/ui/stream_info_dialog.rs:67
+#: src/ui/stream_info_dialog.rs:73
 msgid "Supports Direct Stream"
 msgstr ""
 
-#: src/ui/stream_info_dialog.rs:70
+#: src/ui/stream_info_dialog.rs:77
 msgid "Supports Transcoding"
 msgstr ""
 
-#: src/ui/stream_info_dialog.rs:74
+#: src/ui/stream_info_dialog.rs:83
 msgid "Original Bit Rate"
 msgstr ""
 
-#: src/ui/stream_info_dialog.rs:79
+#: src/ui/stream_info_dialog.rs:89
 msgid "File Size"
 msgstr ""
 
-#: src/ui/stream_info_dialog.rs:106
+#: src/ui/stream_info_dialog.rs:118
 msgid "Stream Info"
 msgstr ""
 
@@ -268,6 +268,7 @@ msgstr ""
 msgid "General"
 msgstr ""
 
+#. TODO: Apparently I didn't know about AdwSwitchRow, these can all be converted
 #: resources/ui/preferences.ui:16
 msgid "Refresh library on startup"
 msgstr ""
@@ -377,12 +378,6 @@ msgstr ""
 
 #: resources/ui/setup.ui:35
 msgid "Host URL"
-msgstr ""
-
-#: resources/ui/setup.ui:37
-msgid ""
-"Enter the complete server address including protocol (http:// or https://) "
-"and port number (:8096)"
 msgstr ""
 
 #: resources/ui/setup.ui:42

--- a/po/gelly.pot
+++ b/po/gelly.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-02 13:16-0700\n"
+"POT-Creation-Date: 2026-06-04 12:54+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,6 +18,17 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
 
+#: src/ui/album_detail.rs:40
+msgid "N/A"
+msgstr ""
+
+#: src/ui/album_detail.rs:169 src/ui/album_detail.rs:179
+#: src/ui/album_detail.rs:203 src/ui/artist_detail.rs:233 src/ui/playlist.rs:62
+#: src/ui/playlist_detail.rs:512 src/ui/playlist_detail.rs:522
+#: src/ui/playlist_detail.rs:546 src/ui/song_list.rs:141
+msgid "Audio model not initialized, please restart"
+msgstr ""
+
 #: src/ui/album_detail.rs:195 src/ui/artist_detail.rs:225
 #: src/ui/playlist_detail.rs:538
 #, rust-format
@@ -25,6 +36,39 @@ msgid "1 song added to queue"
 msgid_plural "{} songs added to queue"
 msgstr[0] ""
 msgstr[1] ""
+
+#: src/ui/music_context_menu.rs:35
+msgid "Queue Next"
+msgstr ""
+
+#: src/ui/music_context_menu.rs:39
+msgid "Queue Last"
+msgstr ""
+
+#: src/ui/music_context_menu.rs:61
+msgid "Add to Playlist"
+msgstr ""
+
+#: src/ui/music_context_menu.rs:65
+msgid "Remove from Playlist"
+msgstr ""
+
+#: src/ui/music_context_menu.rs:73
+msgid "Copy ID"
+msgstr ""
+
+#: src/ui/player_bar/common.rs:73
+msgid "Pause"
+msgstr ""
+
+#: src/ui/player_bar/common.rs:76 resources/ui/album_detail.ui:119
+#: resources/ui/artist_detail.ui:52 resources/ui/playlist_detail.ui:101
+msgid "Play"
+msgstr ""
+
+#: src/ui/player_bar/common.rs:86
+msgid "Unknown Artist"
+msgstr ""
 
 #: src/ui/playlist.rs:27
 #, rust-format
@@ -39,6 +83,35 @@ msgstr ""
 
 #: src/ui/playlist.rs:32
 msgid "Empty playlist"
+msgstr ""
+
+#: src/ui/playlist_detail.rs:564
+msgid "Smart playlists cannot be deleted"
+msgstr ""
+
+#: src/ui/playlist_dialogs.rs:7
+msgid "Playlist name"
+msgstr ""
+
+#: src/ui/playlist_dialogs.rs:16
+msgid "New Playlist"
+msgstr ""
+
+#: src/ui/playlist_dialogs.rs:20 src/ui/playlist_dialogs.rs:59
+#: resources/ui/setup.ui:123 resources/ui/setup.ui:186
+msgid "Cancel"
+msgstr ""
+
+#: src/ui/playlist_dialogs.rs:20
+msgid "Create"
+msgstr ""
+
+#: src/ui/playlist_dialogs.rs:56
+msgid "Delete playlist?"
+msgstr ""
+
+#: src/ui/playlist_dialogs.rs:59
+msgid "Delete"
 msgstr ""
 
 #: src/ui/setup.rs:218
@@ -57,95 +130,234 @@ msgstr ""
 msgid "Quick connect code copied to clipboard"
 msgstr ""
 
+#: src/ui/stream_info_dialog.rs:19
+msgid "Yes"
+msgstr ""
+
+#: src/ui/stream_info_dialog.rs:20
+msgid "No"
+msgstr ""
+
+#: src/ui/stream_info_dialog.rs:21 src/ui/stream_info_dialog.rs:29
+#: src/ui/stream_info_dialog.rs:51
+msgid "Unknown"
+msgstr ""
+
+#: src/ui/stream_info_dialog.rs:28
+msgid "Backend"
+msgstr ""
+
+#: src/ui/stream_info_dialog.rs:29
+msgid "Codec"
+msgstr ""
+
+#: src/ui/stream_info_dialog.rs:31
+msgid "Container"
+msgstr ""
+
+#: src/ui/stream_info_dialog.rs:32 src/ui/stream_info_dialog.rs:55
+msgid "None"
+msgstr ""
+
+#: src/ui/stream_info_dialog.rs:35
+msgid "Sample Rate"
+msgstr ""
+
+#: src/ui/stream_info_dialog.rs:38
+msgid "Channels"
+msgstr ""
+
+#: src/ui/stream_info_dialog.rs:41
+msgid "Bit Rate"
+msgstr ""
+
+#: src/ui/stream_info_dialog.rs:44
+msgid "Encoder"
+msgstr ""
+
+#: src/ui/stream_info_dialog.rs:50
+msgid "Original Codec"
+msgstr ""
+
+#: src/ui/stream_info_dialog.rs:54
+msgid "Original Container"
+msgstr ""
+
+#: src/ui/stream_info_dialog.rs:58
+msgid "Original Sample Rate"
+msgstr ""
+
+#: src/ui/stream_info_dialog.rs:62
+msgid "Original Channels"
+msgstr ""
+
+#: src/ui/stream_info_dialog.rs:65
+msgid "Supports Direct Play"
+msgstr ""
+
+#: src/ui/stream_info_dialog.rs:67
+msgid "Supports Direct Stream"
+msgstr ""
+
+#: src/ui/stream_info_dialog.rs:70
+msgid "Supports Transcoding"
+msgstr ""
+
+#: src/ui/stream_info_dialog.rs:74
+msgid "Original Bit Rate"
+msgstr ""
+
+#: src/ui/stream_info_dialog.rs:79
+msgid "File Size"
+msgstr ""
+
+#: src/ui/stream_info_dialog.rs:106
+msgid "Stream Info"
+msgstr ""
+
+#: src/ui/window.rs:189
+msgid "Logged out"
+msgstr ""
+
 #: resources/ui/album_art.ui:33
 msgid "Missing album art"
 msgstr ""
 
+#: resources/ui/album_detail.ui:82 resources/ui/playlist_detail.ui:66
+msgid "tracks"
+msgstr ""
+
+#: resources/ui/album_detail.ui:145 resources/ui/artist_detail.ui:79
+msgid "More Actions"
+msgstr ""
+
+#: resources/ui/album_list.ui:8
+msgid "No Albums"
+msgstr ""
+
+#: resources/ui/artist_detail.ui:41
+msgid "Artist Name"
+msgstr ""
+
+#: resources/ui/artist_list.ui:8
+msgid "No Artists"
+msgstr ""
+
+#: resources/ui/lyrics.ui:56
+msgid "No lyrics available"
+msgstr ""
+
+#: resources/ui/playlist_detail.ui:127
+msgid "More actions"
+msgstr ""
+
+#: resources/ui/playlist_detail.ui:138
+msgid "Delete playlist"
+msgstr ""
+
+#: resources/ui/playlist_detail.ui:152
+msgid "Playlist is Empty"
+msgstr ""
+
+#: resources/ui/playlist_list.ui:8
+msgid "No Playlists"
+msgstr ""
+
 #: resources/ui/preferences.ui:9 resources/ui/preferences.ui:12
+#: resources/ui/shortcuts_dialog.ui:6
 msgid "General"
 msgstr ""
 
-#: resources/ui/preferences.ui:15
+#: resources/ui/preferences.ui:16
 msgid "Refresh library on startup"
 msgstr ""
 
-#: resources/ui/preferences.ui:16
+#: resources/ui/preferences.ui:17
 msgid "The library can be refreshed using ctrl+r or the menu."
 msgstr ""
 
-#: resources/ui/preferences.ui:28
+#: resources/ui/preferences.ui:29
 msgid "Extra eye candy"
 msgstr ""
 
-#: resources/ui/preferences.ui:29
+#: resources/ui/preferences.ui:30
 msgid "Utilizes transparency, blurred backgrounds, etc."
 msgstr ""
 
+#: resources/ui/preferences.ui:35
+msgid "Compact Mode"
+msgstr ""
+
 #: resources/ui/preferences.ui:36
+msgid "Use smaller UI elements regardless of window size."
+msgstr ""
+
+#: resources/ui/preferences.ui:43 resources/ui/shortcuts_dialog.ui:84
 msgid "Playback"
 msgstr ""
 
-#: resources/ui/preferences.ui:39
+#: resources/ui/preferences.ui:46
 msgid "Normalize Audio"
 msgstr ""
 
-#: resources/ui/preferences.ui:40
+#: resources/ui/preferences.ui:47
 msgid "May require backend plugins."
 msgstr ""
 
-#: resources/ui/preferences.ui:52
+#: resources/ui/preferences.ui:59
 msgid "Inhibit Suspend"
 msgstr ""
 
-#: resources/ui/preferences.ui:53
+#: resources/ui/preferences.ui:60
 msgid "Prevents the system from suspending while playing"
 msgstr ""
 
-#: resources/ui/preferences.ui:67
+#: resources/ui/preferences.ui:74
 msgid "Transcoding"
 msgstr ""
 
-#: resources/ui/preferences.ui:68
-msgid ""
-"Transcoding reduces stream quality and bandwidth at the expense of "
-"processing power on the server. Note that Subsonic backends cannot seek "
-"transcoded streams."
+#: resources/ui/preferences.ui:75
+msgid "Currently Subsonic backends cannot seek transcoded streams."
 msgstr ""
 
-#: resources/ui/preferences.ui:71
+#: resources/ui/preferences.ui:78
 msgid "Transcoding Profile"
 msgstr ""
 
-#: resources/ui/preferences.ui:72
+#: resources/ui/preferences.ui:79
 msgid "Only used when direct play is not available."
 msgstr ""
 
-#: resources/ui/preferences.ui:85
+#: resources/ui/preferences.ui:92
 msgid "Maximum Bitrate (kbps)"
 msgstr ""
 
-#: resources/ui/preferences.ui:86
+#: resources/ui/preferences.ui:93
 msgid "A value of 0 means no limit."
 msgstr ""
 
-#: resources/ui/preferences.ui:105 resources/ui/window.ui:275
+#: resources/ui/preferences.ui:112 resources/ui/window.ui:271
 msgid "Playlists"
 msgstr ""
 
-#: resources/ui/preferences.ui:108
+#: resources/ui/preferences.ui:115
 msgid "Smart Playlists"
 msgstr ""
 
-#: resources/ui/preferences.ui:111
+#: resources/ui/preferences.ui:118
 msgid "Favorite Mix Playlist"
 msgstr ""
 
-#: resources/ui/preferences.ui:123
+#: resources/ui/preferences.ui:130
 msgid "Shuffled Playlist"
 msgstr ""
 
-#: resources/ui/preferences.ui:135
+#: resources/ui/preferences.ui:142
 msgid "Most Played Playlist"
+msgstr ""
+
+#: resources/ui/queue.ui:8
+msgid "Nothing Playing"
 msgstr ""
 
 #: resources/ui/setup.ui:10
@@ -161,6 +373,16 @@ msgid ""
 "Gelly supports Jellyfin and Subsonic/Navidrome. Enter the full server URL "
 "including protocol and port. For Jellyfin this is usually 8096, Navidrome "
 "uses 4533."
+msgstr ""
+
+#: resources/ui/setup.ui:35
+msgid "Host URL"
+msgstr ""
+
+#: resources/ui/setup.ui:37
+msgid ""
+"Enter the complete server address including protocol (http:// or https://) "
+"and port number (:8096)"
 msgstr ""
 
 #: resources/ui/setup.ui:42
@@ -199,10 +421,6 @@ msgstr ""
 msgid "Launch Gelly"
 msgstr ""
 
-#: resources/ui/setup.ui:123 resources/ui/setup.ui:186
-msgid "Cancel"
-msgstr ""
-
 #: resources/ui/setup.ui:141
 msgid "Quick Connect"
 msgstr ""
@@ -211,102 +429,158 @@ msgstr ""
 msgid "Enter the code on the Jellyfin web page to complete authentication."
 msgstr ""
 
-#: resources/ui/window.ui:57
-msgid "Album Detail"
+#: resources/ui/shortcuts_dialog.ui:9 resources/ui/window.ui:369
+msgid "Refresh Library"
 msgstr ""
 
-#: resources/ui/window.ui:90
-msgid "Artist Detail"
+#: resources/ui/shortcuts_dialog.ui:10
+msgid "Re-downloads the music library"
 msgstr ""
 
-#: resources/ui/window.ui:122
-msgid "Playlist Detail"
+#: resources/ui/shortcuts_dialog.ui:16
+msgid "Request Library Rescan"
 msgstr ""
 
-#: resources/ui/window.ui:145
-msgid "Main"
+#: resources/ui/shortcuts_dialog.ui:17
+msgid "Ask Jellyfin to rescan the library for new or modified files"
 msgstr ""
 
-#: resources/ui/window.ui:154
-msgid "Show Queue"
-msgstr ""
-
-#: resources/ui/window.ui:161
+#: resources/ui/shortcuts_dialog.ui:23 resources/ui/window.ui:157
 msgid "Search"
 msgstr ""
 
-#: resources/ui/window.ui:167
+#: resources/ui/shortcuts_dialog.ui:29
+msgid "Show Favorites"
+msgstr ""
+
+#: resources/ui/shortcuts_dialog.ui:35 resources/ui/window.ui:379
+msgid "Preferences"
+msgstr ""
+
+#: resources/ui/shortcuts_dialog.ui:41 resources/ui/window.ui:383
+msgid "Keyboard Shortcuts"
+msgstr ""
+
+#: resources/ui/shortcuts_dialog.ui:47 resources/ui/window.ui:395
+msgid "Quit"
+msgstr ""
+
+#: resources/ui/shortcuts_dialog.ui:55
+msgid "Navigation"
+msgstr ""
+
+#: resources/ui/shortcuts_dialog.ui:58
+msgid "Focus Albums"
+msgstr ""
+
+#: resources/ui/shortcuts_dialog.ui:64
+msgid "Focus Artists"
+msgstr ""
+
+#: resources/ui/shortcuts_dialog.ui:70
+msgid "Focus Playlist"
+msgstr ""
+
+#: resources/ui/shortcuts_dialog.ui:76
+msgid "Focus Song List"
+msgstr ""
+
+#: resources/ui/shortcuts_dialog.ui:87
+msgid "Play Selected"
+msgstr ""
+
+#: resources/ui/shortcuts_dialog.ui:88
+msgid "Play the currently selected item in the list"
+msgstr ""
+
+#: resources/ui/song_list.ui:8
+msgid "No Songs"
+msgstr ""
+
+#: resources/ui/song_list.ui:35
+msgid "songs"
+msgstr ""
+
+#: resources/ui/window.ui:53
+msgid "Album Detail"
+msgstr ""
+
+#: resources/ui/window.ui:86
+msgid "Artist Detail"
+msgstr ""
+
+#: resources/ui/window.ui:118
+msgid "Playlist Detail"
+msgstr ""
+
+#: resources/ui/window.ui:141
+msgid "Main"
+msgstr ""
+
+#: resources/ui/window.ui:150
+msgid "Show Queue"
+msgstr ""
+
+#: resources/ui/window.ui:163
 msgid "Sort"
 msgstr ""
 
-#: resources/ui/window.ui:174
+#: resources/ui/window.ui:170
 msgid "New"
 msgstr ""
 
-#: resources/ui/window.ui:215
+#: resources/ui/window.ui:195
+msgid "Search..."
+msgstr ""
+
+#: resources/ui/window.ui:211
 msgid "Favorites"
 msgstr ""
 
-#: resources/ui/window.ui:228
+#: resources/ui/window.ui:224
 msgid "Ascending"
 msgstr ""
 
-#: resources/ui/window.ui:235
+#: resources/ui/window.ui:231
 msgid "Descending"
 msgstr ""
 
-#: resources/ui/window.ui:251
+#: resources/ui/window.ui:247
 msgid "Albums"
 msgstr ""
 
-#: resources/ui/window.ui:263
+#: resources/ui/window.ui:259
 msgid "Artists"
 msgstr ""
 
-#: resources/ui/window.ui:287
+#: resources/ui/window.ui:283
 msgid "Songs"
 msgstr ""
 
-#: resources/ui/window.ui:332
+#: resources/ui/window.ui:328
 msgid "Hide Queue"
 msgstr ""
 
-#: resources/ui/window.ui:341
+#: resources/ui/window.ui:337
 msgid "Clear Queue"
 msgstr ""
 
-#: resources/ui/window.ui:348
+#: resources/ui/window.ui:344
 msgid "Save As Playlist"
 msgstr ""
 
-#: resources/ui/window.ui:369
+#: resources/ui/window.ui:365
 msgid "Request Rescan"
 msgstr ""
 
 #: resources/ui/window.ui:373
-msgid "Refresh Library"
-msgstr ""
-
-#: resources/ui/window.ui:377
 msgid "Clear Image Cache"
 msgstr ""
 
-#: resources/ui/window.ui:383
-msgid "Preferences"
-msgstr ""
-
 #: resources/ui/window.ui:387
-msgid "Keyboard Shortcuts"
-msgstr ""
-
-#: resources/ui/window.ui:391
 msgid "About Gelly"
 msgstr ""
 
-#: resources/ui/window.ui:395
+#: resources/ui/window.ui:391
 msgid "Logout"
-msgstr ""
-
-#: resources/ui/window.ui:399
-msgid "Quit"
 msgstr ""

--- a/resources/ui/album_detail.ui
+++ b/resources/ui/album_detail.ui
@@ -79,7 +79,7 @@
                     <property name="focusable">False</property>
                     <property name="halign">start</property>
                     <property name="ellipsize">middle</property>
-                    <property name="label">tracks</property>
+                    <property name="label" translatable="yes">tracks</property>
                     <style>
                       <class name="dimmed" />
                     </style>
@@ -116,7 +116,7 @@
                     <property
                       name="icon-name"
                     >media-playback-start-symbolic</property>
-                    <property name="tooltip-text">Play</property>
+                    <property name="tooltip-text" translatable="yes">Play</property>
                     <style>
                       <class name="circular" />
                     </style>
@@ -142,7 +142,7 @@
                     <property
                       name="icon-name"
                     >view-more-symbolic</property>
-                    <property name="tooltip-text">More Actions</property>
+                    <property name="tooltip-text" translatable="yes">More Actions</property>
                     <style>
                       <class name="circular" />
                     </style>

--- a/resources/ui/album_list.ui
+++ b/resources/ui/album_list.ui
@@ -5,7 +5,7 @@
     <property name="orientation">vertical</property>
     <child>
       <object class="AdwStatusPage" id="empty">
-        <property name="title">No Albums</property>
+        <property name="title" translatable="yes">No Albums</property>
         <property name="icon-name">audio-x-generic-symbolic</property>
         <property name="visible">true</property>
       </object>

--- a/resources/ui/artist_detail.ui
+++ b/resources/ui/artist_detail.ui
@@ -38,7 +38,7 @@
                 <property name="margin-bottom">24</property>
                 <child>
                   <object class="GtkLabel" id="artist_name">
-                    <property name="label">Artist Name</property>
+                    <property name="label" translatable="yes">Artist Name</property>
                     <property name="halign">start</property>
                     <property name="ellipsize">end</property>
                     <style>
@@ -49,7 +49,7 @@
                 <child>
                   <object class="GtkButton" id="play_all">
                     <property name="icon-name">media-playback-start-symbolic</property>
-                    <property name="tooltip-text">Play</property>
+                    <property name="tooltip-text" translatable="yes">Play</property>
                     <property name="margin-start">24</property>
                     <style>
                       <class name="circular" />
@@ -76,7 +76,7 @@
                 <child>
                   <object class="GtkMenuButton" id="action_menu">
                     <property name="icon-name">view-more-symbolic</property>
-                    <property name="tooltip-text">More Actions</property>
+                    <property name="tooltip-text" translatable="yes">More Actions</property>
                     <style>
                       <class name="circular" />
                       <class name="opaque" />

--- a/resources/ui/artist_list.ui
+++ b/resources/ui/artist_list.ui
@@ -5,7 +5,7 @@
     <property name="orientation">vertical</property>
     <child>
       <object class="AdwStatusPage" id="empty">
-        <property name="title">No Artists</property>
+        <property name="title" translatable="yes">No Artists</property>
         <property name="icon-name">audio-x-generic-symbolic</property>
         <property name="visible">true</property>
       </object>

--- a/resources/ui/lyrics.ui
+++ b/resources/ui/lyrics.ui
@@ -53,7 +53,7 @@
                 </child>
                 <child>
                   <object class="GtkLabel" id="lyrics_label_empty">
-                    <property name="label">No lyrics available</property>
+                    <property name="label" translatable="yes">No lyrics available</property>
                     <property name="visible">false</property>
                     <property name="wrap">true</property>
                     <property name="justify">center</property>

--- a/resources/ui/playlist_detail.ui
+++ b/resources/ui/playlist_detail.ui
@@ -63,7 +63,7 @@
                     <property name="focusable">False</property>
                     <property name="halign">start</property>
                     <property name="ellipsize">middle</property>
-                    <property name="label">tracks</property>
+                    <property name="label" translatable="yes">tracks</property>
                     <style>
                       <class name="dimmed" />
                     </style>
@@ -98,7 +98,7 @@
                 <child>
                   <object class="GtkButton" id="play_all">
                     <property name="icon-name">media-playback-start-symbolic</property>
-                    <property name="tooltip-text">Play</property>
+                    <property name="tooltip-text" translatable="yes">Play</property>
                     <style>
                       <class name="circular" />
                     </style>
@@ -124,7 +124,7 @@
                     <property
                       name="icon-name"
                     >view-more-symbolic</property>
-                    <property name="tooltip-text">More actions</property>
+                    <property name="tooltip-text" translatable="yes">More actions</property>
                     <style>
                       <class name="circular" />
                     </style>
@@ -135,7 +135,7 @@
                     <property
                       name="icon-name"
                     >user-trash-symbolic</property>
-                    <property name="tooltip-text">Delete playlist</property>
+                    <property name="tooltip-text" translatable="yes">Delete playlist</property>
                     <style>
                       <class name="circular" />
                     </style>
@@ -149,7 +149,7 @@
     </child>
     <child>
       <object class="AdwStatusPage" id="empty">
-        <property name="title">Playlist is Empty</property>
+        <property name="title" translatable="yes">Playlist is Empty</property>
         <property name="icon-name">audio-x-generic-symbolic</property>
         <property name="visible">false</property>
       </object>

--- a/resources/ui/playlist_list.ui
+++ b/resources/ui/playlist_list.ui
@@ -5,7 +5,7 @@
     <property name="orientation">vertical</property>
     <child>
       <object class="AdwStatusPage" id="empty">
-        <property name="title">No Playlists</property>
+        <property name="title" translatable="yes">No Playlists</property>
         <property name="icon-name">audio-x-generic-symbolic</property>
         <property name="visible">true</property>
       </object>

--- a/resources/ui/queue.ui
+++ b/resources/ui/queue.ui
@@ -5,7 +5,7 @@
     <property name="orientation">vertical</property>
     <child>
       <object class="AdwStatusPage" id="empty">
-        <property name="title">Nothing Playing</property>
+        <property name="title" translatable="yes">Nothing Playing</property>
         <property name="icon-name">audio-x-generic-symbolic</property>
         <property name="visible">true</property>
       </object>

--- a/resources/ui/setup.ui
+++ b/resources/ui/setup.ui
@@ -32,9 +32,9 @@
                                 </style>
                                 <child>
                                   <object class="AdwEntryRow" id="host_entry">
-                                    <property name="title">Host URL</property>
+                                    <property name="title" translatable="yes">Host URL</property>
                                     <property name="input-purpose">url</property>
-                                    <property name="tooltip-text">Enter the complete server address including protocol (http:// or https://) and port number (:8096)</property>
+                                    <property name="tooltip-text" translatable="yes">Enter the complete server address including protocol (http:// or https://) and port number (:8096)</property>
                                   </object>
                                 </child>
                                 <child>

--- a/resources/ui/setup.ui
+++ b/resources/ui/setup.ui
@@ -34,7 +34,7 @@
                                   <object class="AdwEntryRow" id="host_entry">
                                     <property name="title" translatable="yes">Host URL</property>
                                     <property name="input-purpose">url</property>
-                                    <property name="tooltip-text" translatable="yes">Enter the complete server address including protocol (http:// or https://) and port number (:8096)</property>
+                                    <property name="tooltip-text">Enter the complete server address including protocol (http:// or https://) and port number (:8096)</property>
                                   </object>
                                 </child>
                                 <child>

--- a/resources/ui/shortcuts_dialog.ui
+++ b/resources/ui/shortcuts_dialog.ui
@@ -3,48 +3,48 @@
   <object class="AdwShortcutsDialog" id="shortcuts-dialog">
     <child>
       <object class="AdwShortcutsSection">
-        <property name="title">General</property>
+        <property name="title" translatable="yes">General</property>
         <child>
           <object class="AdwShortcutsItem">
-            <property name="title">Refresh Library</property>
-            <property name="subtitle">Re-downloads the music library</property>
+            <property name="title" translatable="yes">Refresh Library</property>
+            <property name="subtitle" translatable="yes">Re-downloads the music library</property>
             <property name="action-name">win.refresh-library</property>
           </object>
         </child>
         <child>
           <object class="AdwShortcutsItem">
-            <property name="title">Request Library Rescan</property>
-            <property name="subtitle">Ask Jellyfin to rescan the library for new or modified files</property>
+            <property name="title" translatable="yes">Request Library Rescan</property>
+            <property name="subtitle" translatable="yes">Ask Jellyfin to rescan the library for new or modified files</property>
             <property name="action-name">win.request-library-rescan</property>
           </object>
         </child>
         <child>
           <object class="AdwShortcutsItem">
-            <property name="title">Search</property>
+            <property name="title" translatable="yes">Search</property>
             <property name="action-name">win.search</property>
           </object>
         </child>
         <child>
           <object class="AdwShortcutsItem">
-            <property name="title">Show Favorites</property>
+            <property name="title" translatable="yes">Show Favorites</property>
             <property name="action-name">win.favorites</property>
           </object>
         </child>
         <child>
           <object class="AdwShortcutsItem">
-            <property name="title">Preferences</property>
+            <property name="title" translatable="yes">Preferences</property>
             <property name="action-name">win.preferences</property>
           </object>
         </child>
         <child>
           <object class="AdwShortcutsItem">
-            <property name="title">Keyboard Shortcuts</property>
+            <property name="title" translatable="yes">Keyboard Shortcuts</property>
             <property name="action-name">win.shortcuts</property>
           </object>
         </child>
         <child>
           <object class="AdwShortcutsItem">
-            <property name="title">Quit</property>
+            <property name="title" translatable="yes">Quit</property>
             <property name="action-name">window.close</property>
           </object>
         </child>
@@ -52,28 +52,28 @@
     </child>
     <child>
       <object class="AdwShortcutsSection">
-        <property name="title">Navigation</property>
+        <property name="title" translatable="yes">Navigation</property>
         <child>
           <object class="AdwShortcutsItem">
-            <property name="title">Focus Albums</property>
+            <property name="title" translatable="yes">Focus Albums</property>
             <property name="action-name">win.show-album-list</property>
           </object>
         </child>
         <child>
           <object class="AdwShortcutsItem">
-            <property name="title">Focus Artists</property>
+            <property name="title" translatable="yes">Focus Artists</property>
             <property name="action-name">win.show-artist-list</property>
           </object>
         </child>
         <child>
           <object class="AdwShortcutsItem">
-            <property name="title">Focus Playlist</property>
+            <property name="title" translatable="yes">Focus Playlist</property>
             <property name="action-name">win.show-playlist-list</property>
           </object>
         </child>
         <child>
           <object class="AdwShortcutsItem">
-            <property name="title">Focus Song List</property>
+            <property name="title" translatable="yes">Focus Song List</property>
             <property name="action-name">win.show-song-list</property>
           </object>
         </child>
@@ -81,11 +81,11 @@
     </child>
     <child>
       <object class="AdwShortcutsSection">
-        <property name="title">Playback</property>
+        <property name="title" translatable="yes">Playback</property>
         <child>
           <object class="AdwShortcutsItem">
-            <property name="title">Play Selected</property>
-            <property name="subtitle">Play the currently selected item in the list</property>
+            <property name="title" translatable="yes">Play Selected</property>
+            <property name="subtitle" translatable="yes">Play the currently selected item in the list</property>
             <property name="action-name">win.play-selected</property>
           </object>
         </child>

--- a/resources/ui/song_list.ui
+++ b/resources/ui/song_list.ui
@@ -5,7 +5,7 @@
     <property name="orientation">vertical</property>
     <child>
       <object class="AdwStatusPage" id="empty">
-        <property name="title">No Songs</property>
+        <property name="title" translatable="yes">No Songs</property>
         <property name="icon-name">audio-x-generic-symbolic</property>
         <property name="visible">true</property>
       </object>
@@ -32,7 +32,7 @@
                 </child>
                 <child>
                   <object class="GtkLabel">
-                    <property name="label">songs</property>
+                    <property name="label" translatable="yes">songs</property>
                     <property name="halign">start</property>
                     <style>
                       <class name="title-2" />

--- a/resources/ui/window.ui
+++ b/resources/ui/window.ui
@@ -192,7 +192,7 @@
                                             <property name="search-mode-enabled">false</property>
                                             <property name="child">
                                               <object class="GtkSearchEntry" id="search_entry">
-                                                <property name="placeholder-text">Search...</property>
+                                                <property name="placeholder-text" translatable="yes">Search...</property>
                                               </object>
                                             </property>
                                           </object>

--- a/src/ui/album_detail.rs
+++ b/src/ui/album_detail.rs
@@ -1,6 +1,6 @@
 use crate::{
     async_utils::spawn_tokio,
-    i18n::ngettext,
+    i18n::{ngettext, tr},
     jellyfin::utils::format_duration,
     models::{AlbumModel, SongModel},
     ui::{
@@ -37,7 +37,7 @@ impl DetailPage for AlbumDetail {
         if model.year() > 0 {
             imp.year_label.set_text(&model.year().to_string());
         } else {
-            imp.year_label.set_text("N/A");
+            imp.year_label.set_text(&tr("N/A"));
         }
         imp.album_image.set_item_id(&model.id(), None);
         let binding = model
@@ -166,7 +166,7 @@ impl AlbumDetail {
         if let Some(audio_model) = self.get_application().audio_model() {
             audio_model.set_queue(songs, index, true);
         } else {
-            self.toast("Audio model not initialized, please restart", None);
+            self.toast(&tr("Audio model not initialized, please restart"), None);
             warn!("No audio model found");
         }
     }
@@ -176,7 +176,7 @@ impl AlbumDetail {
         if let Some(audio_model) = self.get_application().audio_model() {
             audio_model.set_queue(songs, 0, false);
         } else {
-            self.toast("Audio model not initialized, please restart", None);
+            self.toast(&tr("Audio model not initialized, please restart"), None);
             warn!("No audio model found");
         }
     }
@@ -200,7 +200,7 @@ impl AlbumDetail {
                 None,
             );
         } else {
-            self.toast("Audio model not initialized, please restart", None);
+            self.toast(&tr("Audio model not initialized, please restart"), None);
             warn!("No audio model found");
         }
     }
@@ -265,7 +265,7 @@ impl AlbumDetail {
             move || {
                 let id = album.id();
                 album.clipboard().set_text(&id);
-                album.toast("Album ID copied to clipboard", None);
+                album.toast(&tr("Album ID copied to clipboard"), None);
             }
         );
 
@@ -298,11 +298,11 @@ impl AlbumDetail {
                 move |result| {
                     match result {
                         Ok(()) => {
-                            album.toast("Added album to playlist", None);
+                            album.toast(&tr("Added album to playlist"), None);
                             app.refresh_playlists(true);
                         }
                         Err(e) => {
-                            album.toast("Failed to add album to playlist", None);
+                            album.toast(&tr("Failed to add album to playlist"), None);
                             warn!("Failed to add album to playlist: {}", e);
                         }
                     }

--- a/src/ui/artist_detail.rs
+++ b/src/ui/artist_detail.rs
@@ -1,6 +1,6 @@
 use crate::{
     async_utils::spawn_tokio,
-    i18n::ngettext,
+    i18n::{ngettext, tr},
     jellyfin::api::ImageType,
     library_utils::play_artist,
     models::{AlbumModel, ArtistModel},
@@ -161,7 +161,7 @@ impl ArtistDetail {
             move || {
                 let id = artist.id();
                 artist.clipboard().set_text(&id);
-                artist.toast("Artist ID copied to clipboard", None);
+                artist.toast(&tr("Artist ID copied to clipboard"), None);
             }
         );
 
@@ -194,11 +194,11 @@ impl ArtistDetail {
                     move |result| {
                         match result {
                             Ok(()) => {
-                                artist.toast("Added artist to playlist", None);
+                                artist.toast(&tr("Added artist to playlist"), None);
                                 app.refresh_playlists(true);
                             }
                             Err(e) => {
-                                artist.toast("Failed to add artist to playlist", None);
+                                artist.toast(&tr("Failed to add artist to playlist"), None);
                                 warn!("Failed to add artist to playlist: {}", e);
                             }
                         }
@@ -230,7 +230,7 @@ impl ArtistDetail {
                     None,
                 );
             } else {
-                self.toast("Audio model not initialized, please restart", None);
+                self.toast(&tr("Audio model not initialized, please restart"), None);
                 warn!("No audio model found");
             }
         }

--- a/src/ui/music_context_menu.rs
+++ b/src/ui/music_context_menu.rs
@@ -1,5 +1,6 @@
 use gtk::{self, gio, glib, prelude::*};
 
+use crate::i18n::tr;
 use crate::jellyfin::api::PlaylistDto;
 
 #[derive(Debug, Clone)]
@@ -31,11 +32,11 @@ fn create_menu_model(config: &ContextActions, playlists: &[PlaylistDto]) -> gio:
     if !config.in_queue {
         let queue_section = gio::Menu::new();
         queue_section.append(
-            Some("Queue Next"),
+            Some(&tr("Queue Next")),
             Some(&format!("{}.queue_next", config.action_prefix)),
         );
         queue_section.append(
-            Some("Queue Last"),
+            Some(&tr("Queue Last")),
             Some(&format!("{}.queue_last", config.action_prefix)),
         );
         menu.append_section(None, &queue_section);
@@ -57,11 +58,11 @@ fn create_menu_model(config: &ContextActions, playlists: &[PlaylistDto]) -> gio:
             );
             playlist_submenu.append_item(&menu_item);
         }
-        playlist_section.append_submenu(Some("Add to Playlist"), &playlist_submenu);
+        playlist_section.append_submenu(Some(&tr("Add to Playlist")), &playlist_submenu);
     }
     if config.can_remove_from_playlist {
         playlist_section.append(
-            Some("Remove from Playlist"),
+            Some(&tr("Remove from Playlist")),
             Some(&format!("{}.remove_playlist", config.action_prefix)),
         );
     }
@@ -69,7 +70,7 @@ fn create_menu_model(config: &ContextActions, playlists: &[PlaylistDto]) -> gio:
 
     let other_section = gio::Menu::new();
     other_section.append(
-        Some("Copy ID"),
+        Some(&tr("Copy ID")),
         Some(&format!("{}.copy_id", config.action_prefix)),
     );
     menu.append_section(None, &other_section);

--- a/src/ui/player_bar/common.rs
+++ b/src/ui/player_bar/common.rs
@@ -1,6 +1,7 @@
 use crate::{
     async_utils::spawn_tokio,
     audio::{model::AudioModel, stream_info::discover_stream_info},
+    i18n::tr,
     jellyfin::api::ItemType,
     ui::{
         album_art::AlbumArt, lyrics::Lyrics, stream_info_dialog, widget_ext::WidgetApplicationExt,
@@ -69,10 +70,10 @@ where
         let btn = self.play_pause_button();
         if playing {
             btn.set_icon_name("media-playback-pause-symbolic");
-            btn.set_tooltip_text(Some("Pause"));
+            btn.set_tooltip_text(Some(&tr("Pause")));
         } else {
             btn.set_icon_name("media-playback-start-symbolic");
-            btn.set_tooltip_text(Some("Play"));
+            btn.set_tooltip_text(Some(&tr("Play")));
         }
     }
 
@@ -82,7 +83,7 @@ where
         let artists = audio_model.current_song_artists();
         let album = audio_model.current_song_album();
         let artist_str = if artists.is_empty() {
-            "Unknown Artist".to_string()
+            tr("Unknown Artist")
         } else {
             artists.join(", ")
         };

--- a/src/ui/playlist.rs
+++ b/src/ui/playlist.rs
@@ -59,7 +59,7 @@ impl Playlist {
         if let Some(audio_model) = self.get_application().audio_model() {
             audio_model.set_queue(songs, 0, false);
         } else {
-            self.toast("Audio model not initialized, please restart", None);
+            self.toast(&tr("Audio model not initialized, please restart"), None);
             warn!("No audio model found");
         }
     }
@@ -83,7 +83,7 @@ impl Playlist {
                             playlist.play_songs(songs);
                         }
                         Err(error) => {
-                            playlist.toast("Unable to load playlist", None);
+                            playlist.toast(&tr("Unable to load playlist"), None);
                             warn!("Unable to load playlist: {error}");
                         }
                     }

--- a/src/ui/playlist_detail.rs
+++ b/src/ui/playlist_detail.rs
@@ -597,8 +597,11 @@ impl PlaylistDetail {
                             playlist_detail.toast(&tr("Playlist deleted"), None);
                         }
                         Err(err) => {
-                            playlist_detail
-                                .toast(&tr("Failed to delete playlist: {}").replace("{}", &err.to_string()), None);
+                            playlist_detail.toast(
+                                &tr("Failed to delete playlist: {}")
+                                    .replace("{}", &err.to_string()),
+                                None,
+                            );
                             error!("Failed to delete playlist: {}", err);
                         }
                     }

--- a/src/ui/playlist_detail.rs
+++ b/src/ui/playlist_detail.rs
@@ -1,7 +1,7 @@
 use crate::{
     async_utils::spawn_tokio,
     backend::BackendError,
-    i18n::ngettext,
+    i18n::{ngettext, tr},
     jellyfin::utils::format_duration,
     library_utils::songs_for_playlist,
     models::{PlaylistModel, SongModel},
@@ -257,7 +257,7 @@ impl PlaylistDetail {
                         }
                         Err(error) => {
                             playlist_detail
-                                .toast("Could not load playlist, please try again.", None);
+                                .toast(&tr("Could not load playlist, please try again."), None);
                             warn!("Unable to load playlist: {error}");
                         }
                     }
@@ -330,7 +330,7 @@ impl PlaylistDetail {
                 if let Some(model) = playlist.get_model() {
                     let id = model.id();
                     playlist.clipboard().set_text(&id);
-                    playlist.toast("Playlist ID copied to clipboard", None);
+                    playlist.toast(&tr("Playlist ID copied to clipboard"), None);
                 }
             }
         );
@@ -364,11 +364,11 @@ impl PlaylistDetail {
                 move |result| {
                     match result {
                         Ok(()) => {
-                            playlist.toast("Added songs to playlist", None);
+                            playlist.toast(&tr("Added songs to playlist"), None);
                             app.refresh_playlists(true);
                         }
                         Err(e) => {
-                            playlist.toast("Failed to add songs to playlist", None);
+                            playlist.toast(&tr("Failed to add songs to playlist"), None);
                             warn!("Failed to add songs to playlist: {}", e);
                         }
                     }
@@ -447,7 +447,7 @@ impl PlaylistDetail {
                     }
                     Err(error) => {
                         log::error!("Failed to move playlist item: {}", error);
-                        playlist_detail.toast("Failed to save playlist order.", None);
+                        playlist_detail.toast(&tr("Failed to save playlist order."), None);
                         // Revert to server state
                         playlist_detail.pull_tracks();
                     }
@@ -493,7 +493,7 @@ impl PlaylistDetail {
                             }
                             Err(error) => {
                                 log::error!("Failed to remove song from playlist: {}", error);
-                                playlist_detail.toast("Failed to modify playlist.", None);
+                                playlist_detail.toast(&tr("Failed to modify playlist."), None);
                                 // Revert to server state
                                 playlist_detail.pull_tracks();
                             }
@@ -509,7 +509,7 @@ impl PlaylistDetail {
         if let Some(audio_model) = self.get_application().audio_model() {
             audio_model.set_queue(songs, index, true);
         } else {
-            self.toast("Audio model not initialized, please restart", None);
+            self.toast(&tr("Audio model not initialized, please restart"), None);
             warn!("No audio model found");
         }
     }
@@ -519,7 +519,7 @@ impl PlaylistDetail {
         if let Some(audio_model) = self.get_application().audio_model() {
             audio_model.set_queue(songs, 0, false);
         } else {
-            self.toast("Audio model not initialized, please restart", None);
+            self.toast(&tr("Audio model not initialized, please restart"), None);
             warn!("No audio model found");
         }
     }
@@ -543,7 +543,7 @@ impl PlaylistDetail {
                 None,
             );
         } else {
-            self.toast("Audio model not initialized, please restart", None);
+            self.toast(&tr("Audio model not initialized, please restart"), None);
             warn!("No audio model found");
         }
     }
@@ -561,7 +561,7 @@ impl PlaylistDetail {
         if let Some(model) = self.get_model()
             && model.is_smart()
         {
-            self.toast("Smart playlists cannot be deleted", None);
+            self.toast(&tr("Smart playlists cannot be deleted"), None);
             return;
         }
 
@@ -594,11 +594,11 @@ impl PlaylistDetail {
                         Ok(()) => {
                             app.refresh_playlists(true);
                             window.go_back();
-                            playlist_detail.toast("Playlist deleted", None);
+                            playlist_detail.toast(&tr("Playlist deleted"), None);
                         }
                         Err(err) => {
                             playlist_detail
-                                .toast(&format!("Failed to delete playlist: {}", err), None);
+                                .toast(&tr("Failed to delete playlist: {}").replace("{}", &err.to_string()), None);
                             error!("Failed to delete playlist: {}", err);
                         }
                     }

--- a/src/ui/playlist_detail.rs
+++ b/src/ui/playlist_detail.rs
@@ -597,11 +597,7 @@ impl PlaylistDetail {
                             playlist_detail.toast(&tr("Playlist deleted"), None);
                         }
                         Err(err) => {
-                            playlist_detail.toast(
-                                &tr("Failed to delete playlist: {}")
-                                    .replace("{}", &err.to_string()),
-                                None,
-                            );
+                            playlist_detail.toast(&tr("Failed to delete playlist"), None);
                             error!("Failed to delete playlist: {}", err);
                         }
                     }

--- a/src/ui/playlist_dialogs.rs
+++ b/src/ui/playlist_dialogs.rs
@@ -1,9 +1,10 @@
+use crate::i18n::tr;
 use crate::ui::window::Window;
 use adw::prelude::*;
 use gtk::glib;
 
 pub fn new_playlist(parent: Option<&Window>, cb: impl Fn(String) + 'static) {
-    let name_entry = adw::EntryRow::builder().title("Playlist name").build();
+    let name_entry = adw::EntryRow::builder().title(tr("Playlist name")).build();
     let entry_box = gtk::ListBox::builder()
         .margin_top(12)
         .margin_bottom(12)
@@ -12,11 +13,11 @@ pub fn new_playlist(parent: Option<&Window>, cb: impl Fn(String) + 'static) {
     entry_box.append(&name_entry);
 
     let dialog = adw::AlertDialog::builder()
-        .heading("New Playlist")
+        .heading(tr("New Playlist"))
         .extra_child(&entry_box)
         .build();
 
-    dialog.add_responses(&[("cancel", "Cancel"), ("create", "Create")]);
+    dialog.add_responses(&[("cancel", &tr("Cancel")), ("create", &tr("Create"))]);
     dialog.set_response_appearance("create", adw::ResponseAppearance::Suggested);
     dialog.set_default_response(Some("create"));
     dialog.set_close_response("cancel");
@@ -52,10 +53,10 @@ pub fn new_playlist(parent: Option<&Window>, cb: impl Fn(String) + 'static) {
 }
 
 pub fn confirm_delete(parent: Option<&Window>, cb: impl Fn(bool) + 'static) {
-    let dialog = adw::AlertDialog::new(Some("Delete playlist?"), None);
+    let dialog = adw::AlertDialog::new(Some(&tr("Delete playlist?")), None);
     dialog.set_default_response(Some("cancel"));
     dialog.set_close_response("cancel");
-    dialog.add_responses(&[("cancel", "Cancel"), ("delete", "Delete")]);
+    dialog.add_responses(&[("cancel", &tr("Cancel")), ("delete", &tr("Delete"))]);
     dialog.set_response_appearance("delete", adw::ResponseAppearance::Destructive);
     dialog.connect_response(
         None,

--- a/src/ui/playlist_list.rs
+++ b/src/ui/playlist_list.rs
@@ -166,11 +166,7 @@ impl PlaylistList {
                             playlist_list.toast(&tr("Playlist created"), None);
                         }
                         Err(err) => {
-                            playlist_list.toast(
-                                &tr("Failed to create playlist: {}")
-                                    .replace("{}", &err.to_string()),
-                                None,
-                            );
+                            playlist_list.toast(&tr("Failed to create playlist"), None);
                             error!("Failed to create playlist: {}", err);
                         }
                     }

--- a/src/ui/playlist_list.rs
+++ b/src/ui/playlist_list.rs
@@ -3,6 +3,7 @@ use crate::{
     async_utils::spawn_tokio,
     backend::BackendError,
     config,
+    i18n::tr,
     library_utils::songs_for_playlist,
     models::{
         PlaylistModel, SongModel,
@@ -58,13 +59,13 @@ impl TopPage for PlaylistList {
                                     audio_model.set_queue(songs, 0, false);
                                 } else {
                                     playlist_list
-                                        .toast("No audio model found, please restart.", None);
+                                        .toast(&tr("No audio model found, please restart."), None);
                                     log::warn!("No audio model found");
                                 }
                             }
                             Err(error) => {
                                 playlist_list
-                                    .toast("Could not load playlist, please try again.", None);
+                                    .toast(&tr("Could not load playlist, please try again."), None);
                                 warn!("Unable to load playlist: {error}");
                             }
                         }
@@ -162,11 +163,11 @@ impl PlaylistList {
                     match result {
                         Ok(_id) => {
                             app.refresh_playlists(true);
-                            playlist_list.toast("Playlist created", None);
+                            playlist_list.toast(&tr("Playlist created"), None);
                         }
                         Err(err) => {
                             playlist_list
-                                .toast(&format!("Failed to create playlist: {}", err), None);
+                                .toast(&tr("Failed to create playlist: {}").replace("{}", &err.to_string()), None);
                             error!("Failed to create playlist: {}", err);
                         }
                     }

--- a/src/ui/playlist_list.rs
+++ b/src/ui/playlist_list.rs
@@ -166,8 +166,11 @@ impl PlaylistList {
                             playlist_list.toast(&tr("Playlist created"), None);
                         }
                         Err(err) => {
-                            playlist_list
-                                .toast(&tr("Failed to create playlist: {}").replace("{}", &err.to_string()), None);
+                            playlist_list.toast(
+                                &tr("Failed to create playlist: {}")
+                                    .replace("{}", &err.to_string()),
+                                None,
+                            );
                             error!("Failed to create playlist: {}", err);
                         }
                     }

--- a/src/ui/queue.rs
+++ b/src/ui/queue.rs
@@ -124,7 +124,11 @@ impl Queue {
                             queue.toast(&tr("Playlist created"), None);
                         }
                         Err(err) => {
-                            queue.toast(&tr("Failed to create playlist: {}").replace("{}", &err.to_string()), None);
+                            queue.toast(
+                                &tr("Failed to create playlist: {}")
+                                    .replace("{}", &err.to_string()),
+                                None,
+                            );
                             error!("Failed to create playlist: {}", err);
                         }
                     }

--- a/src/ui/queue.rs
+++ b/src/ui/queue.rs
@@ -124,11 +124,7 @@ impl Queue {
                             queue.toast(&tr("Playlist created"), None);
                         }
                         Err(err) => {
-                            queue.toast(
-                                &tr("Failed to create playlist: {}")
-                                    .replace("{}", &err.to_string()),
-                                None,
-                            );
+                            queue.toast(&tr("Failed to create playlist"), None);
                             error!("Failed to create playlist: {}", err);
                         }
                     }

--- a/src/ui/queue.rs
+++ b/src/ui/queue.rs
@@ -1,5 +1,6 @@
 use crate::{
     async_utils::spawn_tokio,
+    i18n::tr,
     models::SongModel,
     ui::{
         playlist_dialogs,
@@ -120,10 +121,10 @@ impl Queue {
                     match result {
                         Ok(_id) => {
                             app.refresh_playlists(true);
-                            queue.toast("Playlist created", None);
+                            queue.toast(&tr("Playlist created"), None);
                         }
                         Err(err) => {
-                            queue.toast(&format!("Failed to create playlist: {}", err), None);
+                            queue.toast(&tr("Failed to create playlist: {}").replace("{}", &err.to_string()), None);
                             error!("Failed to create playlist: {}", err);
                         }
                     }

--- a/src/ui/song.rs
+++ b/src/ui/song.rs
@@ -11,6 +11,7 @@ use log::warn;
 
 use crate::{
     async_utils::spawn_tokio,
+    i18n::tr,
     jellyfin::{api::ItemType, utils::format_duration},
     models::SongModel,
     ui::{
@@ -250,7 +251,7 @@ impl Song {
             move || {
                 let id = song.song_id();
                 song.clipboard().set_text(&id);
-                song.toast("Song ID copied to clipboard", None);
+                song.toast(&tr("Song ID copied to clipboard"), None);
             }
         );
 
@@ -299,11 +300,11 @@ impl Song {
                 move |result| {
                     match result {
                         Ok(()) => {
-                            song.toast("Added song to playlist", None);
+                            song.toast(&tr("Added song to playlist"), None);
                             app.refresh_playlists(true);
                         }
                         Err(e) => {
-                            song.toast("Failed to add song to playlist", None);
+                            song.toast(&tr("Failed to add song to playlist"), None);
                             warn!("Failed to add song to playlist: {}", e);
                         }
                     }

--- a/src/ui/song_list.rs
+++ b/src/ui/song_list.rs
@@ -8,6 +8,7 @@ use log::warn;
 
 use crate::{
     application::Application,
+    i18n::tr,
     models::SongModel,
     ui::{
         list_helpers::create_string_filter,
@@ -137,7 +138,7 @@ impl SongList {
         if let Some(audio_model) = self.get_application().audio_model() {
             audio_model.set_queue(songs, index, true);
         } else {
-            self.toast("Audio model not initialized, please restart", None);
+            self.toast(&tr("Audio model not initialized, please restart"), None);
             warn!("No audio model found");
         }
     }

--- a/src/ui/stream_info_dialog.rs
+++ b/src/ui/stream_info_dialog.rs
@@ -25,7 +25,10 @@ fn yes_no(value: Option<bool>) -> String {
 pub fn show(parent: Option<&Window>, info: StreamInfo) {
     // Local properties
     let mut left_props = vec![
-        (tr("Backend"), config::get_backend_type().as_str().to_string()),
+        (
+            tr("Backend"),
+            config::get_backend_type().as_str().to_string(),
+        ),
         (tr("Codec"), info.codec.unwrap_or_else(|| tr("Unknown"))),
         (
             tr("Container"),
@@ -62,12 +65,18 @@ pub fn show(parent: Option<&Window>, info: StreamInfo) {
             tr("Original Channels"),
             info.original_channels.unwrap_or(0).to_string(),
         ),
-        (tr("Supports Direct Play"), yes_no(info.supports_direct_play)),
+        (
+            tr("Supports Direct Play"),
+            yes_no(info.supports_direct_play),
+        ),
         (
             tr("Supports Direct Stream"),
             yes_no(info.supports_direct_stream),
         ),
-        (tr("Supports Transcoding"), yes_no(info.supports_transcoding)),
+        (
+            tr("Supports Transcoding"),
+            yes_no(info.supports_transcoding),
+        ),
     ];
     if let Some(original_bit_rate) = info.original_bit_rate {
         right_props.push((
@@ -76,7 +85,10 @@ pub fn show(parent: Option<&Window>, info: StreamInfo) {
         ));
     }
     if let Some(file_size) = info.file_size {
-        right_props.push((tr("File Size"), format!("{:.1} MB", file_size / 1024 / 1024)));
+        right_props.push((
+            tr("File Size"),
+            format!("{:.1} MB", file_size / 1024 / 1024),
+        ));
     }
 
     let num_rows = left_props.len().max(right_props.len()) as i32;

--- a/src/ui/stream_info_dialog.rs
+++ b/src/ui/stream_info_dialog.rs
@@ -1,10 +1,11 @@
 use adw::prelude::*;
 use gtk::Window;
 
+use crate::i18n::tr;
 use crate::{audio::stream_info::StreamInfo, config};
 
-fn add_to_grid(row: i32, col_offset: i32, prop: &(&str, String), grid: &gtk::Grid) {
-    let key = gtk::Label::new(Some(prop.0));
+fn add_to_grid(row: i32, col_offset: i32, prop: &(String, String), grid: &gtk::Grid) {
+    let key = gtk::Label::new(Some(&prop.0));
     let value = gtk::Label::new(Some(&prop.1));
     key.set_halign(gtk::Align::End);
     value.set_halign(gtk::Align::Start);
@@ -15,67 +16,67 @@ fn add_to_grid(row: i32, col_offset: i32, prop: &(&str, String), grid: &gtk::Gri
 
 fn yes_no(value: Option<bool>) -> String {
     match value {
-        Some(true) => "Yes".to_string(),
-        Some(false) => "No".to_string(),
-        None => "Unknown".to_string(),
+        Some(true) => tr("Yes"),
+        Some(false) => tr("No"),
+        None => tr("Unknown"),
     }
 }
 
 pub fn show(parent: Option<&Window>, info: StreamInfo) {
     // Local properties
     let mut left_props = vec![
-        ("Backend", config::get_backend_type().as_str().to_string()),
-        ("Codec", info.codec.unwrap_or("Unknown".to_string())),
+        (tr("Backend"), config::get_backend_type().as_str().to_string()),
+        (tr("Codec"), info.codec.unwrap_or_else(|| tr("Unknown"))),
         (
-            "Container",
-            info.container_format.unwrap_or("None".to_string()),
+            tr("Container"),
+            info.container_format.unwrap_or_else(|| tr("None")),
         ),
         (
-            "Sample Rate",
+            tr("Sample Rate"),
             format!("{} Hz", info.sample_rate.unwrap_or(0)),
         ),
-        ("Channels", info.channels.unwrap_or(0).to_string()),
+        (tr("Channels"), info.channels.unwrap_or(0).to_string()),
     ];
     if let Some(bit_rate) = info.bit_rate {
-        left_props.push(("Bit Rate", format!("{} kbps", bit_rate)));
+        left_props.push((tr("Bit Rate"), format!("{} kbps", bit_rate)));
     }
     if let Some(encoder) = info.encoder {
-        left_props.push(("Encoder", encoder));
+        left_props.push((tr("Encoder"), encoder));
     }
 
     // Remote properties
     let mut right_props = vec![
         (
-            "Original Codec",
-            info.original_codec.unwrap_or("Unknown".to_string()),
+            tr("Original Codec"),
+            info.original_codec.unwrap_or_else(|| tr("Unknown")),
         ),
         (
-            "Original Container",
-            info.original_container_format.unwrap_or("None".to_string()),
+            tr("Original Container"),
+            info.original_container_format.unwrap_or_else(|| tr("None")),
         ),
         (
-            "Original Sample Rate",
+            tr("Original Sample Rate"),
             info.original_sample_rate.unwrap_or(0).to_string(),
         ),
         (
-            "Original Channels",
+            tr("Original Channels"),
             info.original_channels.unwrap_or(0).to_string(),
         ),
-        ("Supports Direct Play", yes_no(info.supports_direct_play)),
+        (tr("Supports Direct Play"), yes_no(info.supports_direct_play)),
         (
-            "Supports Direct Stream",
+            tr("Supports Direct Stream"),
             yes_no(info.supports_direct_stream),
         ),
-        ("Supports Transcoding", yes_no(info.supports_transcoding)),
+        (tr("Supports Transcoding"), yes_no(info.supports_transcoding)),
     ];
     if let Some(original_bit_rate) = info.original_bit_rate {
         right_props.push((
-            "Original Bit Rate",
+            tr("Original Bit Rate"),
             format!("{:.1} kbps", original_bit_rate / 1000),
         ));
     }
     if let Some(file_size) = info.file_size {
-        right_props.push(("File Size", format!("{:.1} MB", file_size / 1024 / 1024)));
+        right_props.push((tr("File Size"), format!("{:.1} MB", file_size / 1024 / 1024)));
     }
 
     let num_rows = left_props.len().max(right_props.len()) as i32;
@@ -102,7 +103,7 @@ pub fn show(parent: Option<&Window>, info: StreamInfo) {
 
     // Create a header bar with title
     let header_bar = adw::HeaderBar::new();
-    header_bar.set_title_widget(Some(&adw::WindowTitle::new("Stream Info", "")));
+    header_bar.set_title_widget(Some(&adw::WindowTitle::new(&tr("Stream Info"), "")));
 
     // Create a toolbar view to combine header and content
     let toolbar_view = adw::ToolbarView::new();

--- a/src/ui/window.rs
+++ b/src/ui/window.rs
@@ -1,4 +1,5 @@
 use crate::config::{self, settings};
+use crate::i18n::tr;
 use crate::models::{AlbumModel, ArtistModel, PlaylistModel};
 use crate::ui::page_traits::{DetailPage, TopPage};
 use crate::ui::preferences::Preferences;
@@ -185,7 +186,7 @@ impl Window {
     pub fn logout(&self) {
         self.get_application().logout();
         self.show_server_setup();
-        self.toast("Logged out", None);
+        self.toast(&tr("Logged out"), None);
     }
 
     pub fn save_window_size(&self) -> Result<(), glib::BoolError> {


### PR DESCRIPTION
It was nice that we got the first release with translations!
This improves them by adding all strings I could find. I used AI to identify those, then I added the ones that made sense (`tr()`) and finally ran `just pot`.

Let me know if I missed something.