### PR TITLE
Queue metrics

### DIFF
--- a/po/gelly.pot
+++ b/po/gelly.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-04 16:03-0700\n"
+"POT-Creation-Date: 2026-06-12 08:16-0700\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -23,14 +23,14 @@ msgid "N/A"
 msgstr ""
 
 #: src/ui/album_detail.rs:169 src/ui/album_detail.rs:179
-#: src/ui/album_detail.rs:203 src/ui/artist_detail.rs:233 src/ui/playlist.rs:62
-#: src/ui/playlist_detail.rs:512 src/ui/playlist_detail.rs:522
-#: src/ui/playlist_detail.rs:546 src/ui/song_list.rs:141
+#: src/ui/album_detail.rs:203 src/ui/artist_detail.rs:236 src/ui/playlist.rs:53
+#: src/ui/playlist_detail.rs:515 src/ui/playlist_detail.rs:525
+#: src/ui/playlist_detail.rs:549 src/ui/song_list.rs:141
 msgid "Audio model not initialized, please restart"
 msgstr ""
 
-#: src/ui/album_detail.rs:195 src/ui/artist_detail.rs:225
-#: src/ui/playlist_detail.rs:538
+#: src/ui/album_detail.rs:195 src/ui/artist_detail.rs:228
+#: src/ui/playlist_detail.rs:541
 #, rust-format
 msgid "1 song added to queue"
 msgid_plural "{} songs added to queue"
@@ -70,22 +70,22 @@ msgstr ""
 msgid "Unknown Artist"
 msgstr ""
 
-#: src/ui/playlist.rs:27
+#: src/ui/playlist.rs:26
 #, rust-format
 msgid "1 song"
 msgid_plural "{} songs"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/ui/playlist.rs:30
+#: src/ui/playlist.rs:29
 msgid "Smart playlist"
 msgstr ""
 
-#: src/ui/playlist.rs:32
+#: src/ui/playlist.rs:31
 msgid "Empty playlist"
 msgstr ""
 
-#: src/ui/playlist_detail.rs:564
+#: src/ui/playlist_detail.rs:567
 msgid "Smart playlists cannot be deleted"
 msgstr ""
 
@@ -215,7 +215,7 @@ msgstr ""
 msgid "Stream Info"
 msgstr ""
 
-#: src/ui/window.rs:189
+#: src/ui/window.rs:178
 msgid "Logged out"
 msgstr ""
 
@@ -268,97 +268,100 @@ msgstr ""
 msgid "General"
 msgstr ""
 
-#. TODO: Apparently I didn't know about AdwSwitchRow, these can all be converted
-#: resources/ui/preferences.ui:16
+#: resources/ui/preferences.ui:15
 msgid "Refresh library on startup"
 msgstr ""
 
-#: resources/ui/preferences.ui:17
+#: resources/ui/preferences.ui:16
 msgid "The library can be refreshed using ctrl+r or the menu."
 msgstr ""
 
-#: resources/ui/preferences.ui:29
+#: resources/ui/preferences.ui:21
 msgid "Extra eye candy"
 msgstr ""
 
-#: resources/ui/preferences.ui:30
+#: resources/ui/preferences.ui:22
 msgid "Utilizes transparency, blurred backgrounds, etc."
 msgstr ""
 
-#: resources/ui/preferences.ui:35
+#: resources/ui/preferences.ui:27
 msgid "Compact Mode"
 msgstr ""
 
-#: resources/ui/preferences.ui:36
+#: resources/ui/preferences.ui:28
 msgid "Use smaller UI elements regardless of window size."
 msgstr ""
 
-#: resources/ui/preferences.ui:43 resources/ui/shortcuts_dialog.ui:84
+#: resources/ui/preferences.ui:35 resources/ui/shortcuts_dialog.ui:84
 msgid "Playback"
 msgstr ""
 
-#: resources/ui/preferences.ui:46
+#: resources/ui/preferences.ui:38
 msgid "Normalize Audio"
 msgstr ""
 
-#: resources/ui/preferences.ui:47
+#: resources/ui/preferences.ui:39
 msgid "May require backend plugins."
 msgstr ""
 
-#: resources/ui/preferences.ui:59
+#: resources/ui/preferences.ui:44
 msgid "Inhibit Suspend"
 msgstr ""
 
-#: resources/ui/preferences.ui:60
+#: resources/ui/preferences.ui:45
 msgid "Prevents the system from suspending while playing"
 msgstr ""
 
-#: resources/ui/preferences.ui:74
+#: resources/ui/preferences.ui:52
 msgid "Transcoding"
 msgstr ""
 
-#: resources/ui/preferences.ui:75
+#: resources/ui/preferences.ui:53
 msgid "Currently Subsonic backends cannot seek transcoded streams."
 msgstr ""
 
-#: resources/ui/preferences.ui:78
+#: resources/ui/preferences.ui:56
 msgid "Transcoding Profile"
 msgstr ""
 
-#: resources/ui/preferences.ui:79
+#: resources/ui/preferences.ui:57
 msgid "Only used when direct play is not available."
 msgstr ""
 
-#: resources/ui/preferences.ui:92
+#: resources/ui/preferences.ui:70
 msgid "Maximum Bitrate (kbps)"
 msgstr ""
 
-#: resources/ui/preferences.ui:93
+#: resources/ui/preferences.ui:71
 msgid "A value of 0 means no limit."
 msgstr ""
 
-#: resources/ui/preferences.ui:112 resources/ui/window.ui:271
+#: resources/ui/preferences.ui:90 resources/ui/window.ui:274
 msgid "Playlists"
 msgstr ""
 
-#: resources/ui/preferences.ui:115
+#: resources/ui/preferences.ui:93
 msgid "Smart Playlists"
 msgstr ""
 
-#: resources/ui/preferences.ui:118
+#: resources/ui/preferences.ui:96
 msgid "Favorite Mix Playlist"
 msgstr ""
 
-#: resources/ui/preferences.ui:130
+#: resources/ui/preferences.ui:101
 msgid "Shuffled Playlist"
 msgstr ""
 
-#: resources/ui/preferences.ui:142
+#: resources/ui/preferences.ui:106
 msgid "Most Played Playlist"
 msgstr ""
 
 #: resources/ui/queue.ui:8
 msgid "Nothing Playing"
+msgstr ""
+
+#: resources/ui/queue.ui:41
+msgid "Jump to current song"
 msgstr ""
 
 #: resources/ui/setup.ui:10
@@ -424,7 +427,7 @@ msgstr ""
 msgid "Enter the code on the Jellyfin web page to complete authentication."
 msgstr ""
 
-#: resources/ui/shortcuts_dialog.ui:9 resources/ui/window.ui:369
+#: resources/ui/shortcuts_dialog.ui:9 resources/ui/window.ui:372
 msgid "Refresh Library"
 msgstr ""
 
@@ -440,7 +443,7 @@ msgstr ""
 msgid "Ask Jellyfin to rescan the library for new or modified files"
 msgstr ""
 
-#: resources/ui/shortcuts_dialog.ui:23 resources/ui/window.ui:157
+#: resources/ui/shortcuts_dialog.ui:23 resources/ui/window.ui:160
 msgid "Search"
 msgstr ""
 
@@ -448,15 +451,15 @@ msgstr ""
 msgid "Show Favorites"
 msgstr ""
 
-#: resources/ui/shortcuts_dialog.ui:35 resources/ui/window.ui:379
+#: resources/ui/shortcuts_dialog.ui:35 resources/ui/window.ui:382
 msgid "Preferences"
 msgstr ""
 
-#: resources/ui/shortcuts_dialog.ui:41 resources/ui/window.ui:383
+#: resources/ui/shortcuts_dialog.ui:41 resources/ui/window.ui:386
 msgid "Keyboard Shortcuts"
 msgstr ""
 
-#: resources/ui/shortcuts_dialog.ui:47 resources/ui/window.ui:395
+#: resources/ui/shortcuts_dialog.ui:47 resources/ui/window.ui:398
 msgid "Quit"
 msgstr ""
 
@@ -496,86 +499,86 @@ msgstr ""
 msgid "songs"
 msgstr ""
 
-#: resources/ui/window.ui:53
+#: resources/ui/window.ui:56
 msgid "Album Detail"
 msgstr ""
 
-#: resources/ui/window.ui:86
+#: resources/ui/window.ui:89
 msgid "Artist Detail"
 msgstr ""
 
-#: resources/ui/window.ui:118
+#: resources/ui/window.ui:121
 msgid "Playlist Detail"
 msgstr ""
 
-#: resources/ui/window.ui:141
+#: resources/ui/window.ui:144
 msgid "Main"
 msgstr ""
 
-#: resources/ui/window.ui:150
+#: resources/ui/window.ui:153
 msgid "Show Queue"
 msgstr ""
 
-#: resources/ui/window.ui:163
+#: resources/ui/window.ui:166
 msgid "Sort"
 msgstr ""
 
-#: resources/ui/window.ui:170
+#: resources/ui/window.ui:173
 msgid "New"
 msgstr ""
 
-#: resources/ui/window.ui:195
+#: resources/ui/window.ui:198
 msgid "Search..."
 msgstr ""
 
-#: resources/ui/window.ui:211
+#: resources/ui/window.ui:214
 msgid "Favorites"
 msgstr ""
 
-#: resources/ui/window.ui:224
+#: resources/ui/window.ui:227
 msgid "Ascending"
 msgstr ""
 
-#: resources/ui/window.ui:231
+#: resources/ui/window.ui:234
 msgid "Descending"
 msgstr ""
 
-#: resources/ui/window.ui:247
+#: resources/ui/window.ui:250
 msgid "Albums"
 msgstr ""
 
-#: resources/ui/window.ui:259
+#: resources/ui/window.ui:262
 msgid "Artists"
 msgstr ""
 
-#: resources/ui/window.ui:283
+#: resources/ui/window.ui:286
 msgid "Songs"
 msgstr ""
 
-#: resources/ui/window.ui:328
+#: resources/ui/window.ui:331
 msgid "Hide Queue"
 msgstr ""
 
-#: resources/ui/window.ui:337
+#: resources/ui/window.ui:340
 msgid "Clear Queue"
 msgstr ""
 
-#: resources/ui/window.ui:344
+#: resources/ui/window.ui:347
 msgid "Save As Playlist"
 msgstr ""
 
-#: resources/ui/window.ui:365
+#: resources/ui/window.ui:368
 msgid "Request Rescan"
 msgstr ""
 
-#: resources/ui/window.ui:373
+#: resources/ui/window.ui:376
 msgid "Clear Image Cache"
 msgstr ""
 
-#: resources/ui/window.ui:387
+#: resources/ui/window.ui:390
 msgid "About Gelly"
 msgstr ""
 
-#: resources/ui/window.ui:391
+#: resources/ui/window.ui:394
 msgid "Logout"
 msgstr ""

--- a/resources/style.css
+++ b/resources/style.css
@@ -8,10 +8,6 @@
     padding-left: 7px; /* 12 minus border-left */
 }
 
-.normal-font {
-    font-weight: normal;
-}
-
 .song-link {
     font-weight: normal;
     padding: 0;

--- a/resources/style.css
+++ b/resources/style.css
@@ -8,6 +8,10 @@
     padding-left: 7px; /* 12 minus border-left */
 }
 
+.normal-font {
+    font-weight: normal;
+}
+
 .song-link {
     font-weight: normal;
     padding: 0;

--- a/resources/ui/queue.ui
+++ b/resources/ui/queue.ui
@@ -10,16 +10,38 @@
         <property name="visible">true</property>
       </object>
     </child>
-    <child>
-      <object class="GellyAutoScrollWindow" id="scroll_window">
-        <property name="vexpand">true</property>
-        <property name="content">
-          <object class="GtkListView" id="track_list">
-            <style>
-              <class name="boxed-list" />
-            </style>
+        <child>
+          <object class="GellyAutoScrollWindow" id="scroll_window">
+            <property name="vexpand">true</property>
+            <property name="content">
+              <object class="GtkListView" id="track_list">
+                <style>
+                  <class name="boxed-list" />
+                </style>
+              </object>
+            </property>
           </object>
-        </property>
+        </child>
+    <child>
+      <object class="GtkBox">
+        <property name="orientation">vertical</property>
+        <style>
+          <class name="frame"/>
+        </style>
+        <child>
+          <object class="GtkCenterBox">
+            <property name="margin-bottom">12</property>
+            <property name="margin-top">12</property>
+            <property name="margin-start">12</property>
+            <property name="margin-end">12</property>
+            <child type="start">
+              <object class="GtkLabel" id="queue_position"/>
+            </child>
+            <child type="end">
+              <object class="GtkLabel" id="queue_duration"/>
+            </child>
+          </object>
+        </child>
       </object>
     </child>
   </template>

--- a/resources/ui/queue.ui
+++ b/resources/ui/queue.ui
@@ -27,6 +27,7 @@
         <property name="orientation">vertical</property>
         <style>
           <class name="frame"/>
+          <class name="dimmed"/>
         </style>
         <child>
           <object class="GtkCenterBox">

--- a/resources/ui/queue.ui
+++ b/resources/ui/queue.ui
@@ -36,7 +36,13 @@
             <property name="margin-start">12</property>
             <property name="margin-end">12</property>
             <child type="start">
-              <object class="GtkLabel" id="queue_position"/>
+              <object class="GtkButton" id="queue_position">
+                <property name="has-frame">false</property>
+                <property name="tooltip-text" translatable="yes">Jump to current song</property>
+                <style>
+                  <class name="flat"/>
+                </style>
+              </object>
             </child>
             <child type="end">
               <object class="GtkLabel" id="queue_duration"/>

--- a/resources/ui/queue.ui
+++ b/resources/ui/queue.ui
@@ -31,8 +31,8 @@
         </style>
         <child>
           <object class="GtkCenterBox">
-            <property name="margin-bottom">12</property>
-            <property name="margin-top">12</property>
+            <property name="margin-bottom">6</property>
+            <property name="margin-top">6</property>
             <property name="margin-start">12</property>
             <property name="margin-end">12</property>
             <child type="start">
@@ -41,6 +41,7 @@
                 <property name="tooltip-text" translatable="yes">Jump to current song</property>
                 <style>
                   <class name="flat"/>
+                  <class name="normal-font"/>
                 </style>
               </object>
             </child>

--- a/resources/ui/queue.ui
+++ b/resources/ui/queue.ui
@@ -31,8 +31,8 @@
         </style>
         <child>
           <object class="GtkCenterBox">
-            <property name="margin-bottom">6</property>
-            <property name="margin-top">6</property>
+            <property name="margin-bottom">9</property>
+            <property name="margin-top">9</property>
             <property name="margin-start">12</property>
             <property name="margin-end">12</property>
             <child type="start">

--- a/resources/ui/queue.ui
+++ b/resources/ui/queue.ui
@@ -39,10 +39,6 @@
               <object class="GtkButton" id="queue_position">
                 <property name="has-frame">false</property>
                 <property name="tooltip-text" translatable="yes">Jump to current song</property>
-                <style>
-                  <class name="flat"/>
-                  <class name="normal-font"/>
-                </style>
               </object>
             </child>
             <child type="end">

--- a/src/audio/model.rs
+++ b/src/audio/model.rs
@@ -25,10 +25,12 @@ impl AudioModel {
     pub fn new() -> Self {
         let obj: Self = Object::builder().build();
         obj.initialize_player();
+        obj.connect_queue_store_signals();
         obj.set_queue_index(-1);
         obj.set_volume(config::get_volume());
         obj.set_playback_mode(config::get_playback_mode());
         obj.set_muted(false);
+        obj.refresh_queue_metrics();
         obj
     }
 
@@ -186,6 +188,30 @@ impl AudioModel {
 
     pub fn queue_len(&self) -> i32 {
         self.imp().queue.n_items() as i32
+    }
+
+    pub fn queue_duration(&self) -> u64 {
+        self.queue().iter().map(|s| s.duration()).sum()
+    }
+
+    fn connect_queue_store_signals(&self) {
+        let queue = self.imp().queue.clone();
+        queue.connect_items_changed(glib::clone!(
+            #[weak(rename_to = audio_model)]
+            self,
+            move |_, _, _, _| {
+                audio_model.refresh_queue_metrics();
+            }
+        ));
+    }
+
+    fn refresh_queue_metrics(&self) {
+        let queue_size = self.imp().queue.n_items();
+        let queue_total_duration = self.queue_duration();
+        self.imp().queue_size.set(queue_size);
+        self.imp().queue_total_duration.set(queue_total_duration);
+        self.notify("queue-size");
+        self.notify("queue-total-duration");
     }
 
     pub fn set_queue(&self, songs: Vec<SongModel>, start_index: usize, ignore_shuffle: bool) {
@@ -558,8 +584,14 @@ mod imp {
     #[derive(Properties)]
     #[properties(wrapper_type = super::AudioModel)]
     pub struct AudioModel {
-        #[property(get, set)]
+        #[property(get, set = Self::set_queue_index)]
         pub queue_index: Cell<i32>,
+
+        #[property(get)]
+        pub queue_size: Cell<u32>,
+
+        #[property(get)]
+        pub queue_total_duration: Cell<u64>,
 
         #[property(get, set)]
         pub playing: Cell<bool>,
@@ -601,6 +633,8 @@ mod imp {
         fn default() -> Self {
             Self {
                 queue_index: Cell::new(0),
+                queue_size: Cell::new(0),
+                queue_total_duration: Cell::new(0),
                 playing: Cell::new(false),
                 paused: Cell::new(false),
                 loading: Cell::new(false),
@@ -668,6 +702,11 @@ mod imp {
             } else {
                 PlaybackMode::Normal as u32
             });
+        }
+
+        pub fn set_queue_index(&self, queue_index: i32) {
+            self.queue_index.set(queue_index);
+            self.obj().refresh_queue_metrics();
         }
 
         pub fn set_volume(&self, volume: f64) {

--- a/src/ui/auto_scroll_window.rs
+++ b/src/ui/auto_scroll_window.rs
@@ -30,6 +30,38 @@ impl AutoScrollWindow {
     pub fn vadjustment(&self) -> gtk::Adjustment {
         self.scrolled_window().vadjustment()
     }
+
+    // Paper over timing issues when the list model isn't fully populated yet
+    pub fn scroll_index_to_top(&self, index: u32, item_count: u32) {
+        if item_count == 0 || index >= item_count {
+            return;
+        }
+
+        let auto_scroll = self.clone();
+        glib::timeout_add_local_once(std::time::Duration::from_millis(16), move || {
+            auto_scroll.scroll_index_to_top_now(index, item_count);
+        });
+    }
+
+    fn scroll_index_to_top_now(&self, index: u32, item_count: u32) {
+        let adj = self.vadjustment();
+        let lower = adj.lower();
+        let upper = adj.upper();
+        let page_size = adj.page_size();
+
+        if upper <= lower || page_size <= 0.0 {
+            return;
+        }
+
+        let row_height = (upper - lower) / item_count as f64;
+        if row_height <= 0.0 {
+            return;
+        }
+
+        let target = lower + (index as f64 * row_height);
+        let max_value = (upper - page_size).max(lower);
+        adj.set_value(target.clamp(lower, max_value));
+    }
 }
 
 impl Default for AutoScrollWindow {

--- a/src/ui/auto_scroll_window.rs
+++ b/src/ui/auto_scroll_window.rs
@@ -40,10 +40,16 @@ impl AutoScrollWindow {
             return;
         }
 
-        let auto_scroll = self.clone();
-        glib::timeout_add_local_once(Duration::from_millis(SCROLL_ANIMATION_TICK_MS), move || {
-            auto_scroll.scroll_index_to_top_now(index, item_count);
-        });
+        glib::timeout_add_local_once(
+            Duration::from_millis(SCROLL_ANIMATION_TICK_MS),
+            glib::clone!(
+                #[weak(rename_to = auto_scroll)]
+                self,
+                move || {
+                    auto_scroll.scroll_index_to_top_now(index, item_count);
+                }
+            ),
+        );
     }
 
     fn scroll_index_to_top_now(&self, index: u32, item_count: u32) {
@@ -80,25 +86,32 @@ impl AutoScrollWindow {
         }
 
         let started_at = Instant::now();
-        let auto_scroll = self.clone();
-        let timeout_id =
-            glib::timeout_add_local(Duration::from_millis(SCROLL_ANIMATION_TICK_MS), move || {
-                let elapsed_ms = started_at.elapsed().as_secs_f64() * 1000.0;
-                let t = (elapsed_ms / SCROLL_ANIMATION_DURATION_MS).clamp(0.0, 1.0);
+        let timeout_id = glib::timeout_add_local(
+            Duration::from_millis(SCROLL_ANIMATION_TICK_MS),
+            glib::clone!(
+                #[weak(rename_to = auto_scroll)]
+                self,
+                #[upgrade_or]
+                glib::ControlFlow::Break,
+                move || {
+                    let elapsed_ms = started_at.elapsed().as_secs_f64() * 1000.0;
+                    let t = (elapsed_ms / SCROLL_ANIMATION_DURATION_MS).clamp(0.0, 1.0);
 
-                // ease-out cubic
-                let eased = 1.0 - (1.0 - t).powi(3);
-                let value = start + ((target - start) * eased);
+                    // ease-out cubic
+                    let eased = 1.0 - (1.0 - t).powi(3);
+                    let value = start + ((target - start) * eased);
 
-                auto_scroll.vadjustment().set_value(value);
+                    auto_scroll.vadjustment().set_value(value);
 
-                if t >= 1.0 {
-                    auto_scroll.imp().scroll_animation_timeout_id.take();
-                    glib::ControlFlow::Break
-                } else {
-                    glib::ControlFlow::Continue
+                    if t >= 1.0 {
+                        auto_scroll.imp().scroll_animation_timeout_id.take();
+                        glib::ControlFlow::Break
+                    } else {
+                        glib::ControlFlow::Continue
+                    }
                 }
-            });
+            ),
+        );
 
         imp.scroll_animation_timeout_id.replace(Some(timeout_id));
     }
@@ -125,7 +138,7 @@ mod imp {
         content: RefCell<Option<gtk::Widget>>,
 
         scroll_timeout_id: RefCell<Option<SourceId>>,
-        pub(super) scroll_animation_timeout_id: RefCell<Option<SourceId>>,
+        pub scroll_animation_timeout_id: RefCell<Option<SourceId>>,
         scroll_speed: Cell<f64>,
     }
 

--- a/src/ui/auto_scroll_window.rs
+++ b/src/ui/auto_scroll_window.rs
@@ -1,9 +1,12 @@
 //! Custom implementation of a scrollable window with automatic scrolling during D&D.
 use adw::{prelude::*, subclass::prelude::*};
 use gtk::glib;
+use std::time::{Duration, Instant};
 
 const MARGIN: f64 = 64.0;
 const SPEED: f64 = 25.0;
+const SCROLL_ANIMATION_DURATION_MS: f64 = 140.0;
+const SCROLL_ANIMATION_TICK_MS: u64 = 16;
 
 glib::wrapper! {
     pub struct AutoScrollWindow(ObjectSubclass<imp::AutoScrollWindow>)
@@ -38,7 +41,7 @@ impl AutoScrollWindow {
         }
 
         let auto_scroll = self.clone();
-        glib::timeout_add_local_once(std::time::Duration::from_millis(16), move || {
+        glib::timeout_add_local_once(Duration::from_millis(SCROLL_ANIMATION_TICK_MS), move || {
             auto_scroll.scroll_index_to_top_now(index, item_count);
         });
     }
@@ -60,7 +63,44 @@ impl AutoScrollWindow {
 
         let target = lower + (index as f64 * row_height);
         let max_value = (upper - page_size).max(lower);
-        adj.set_value(target.clamp(lower, max_value));
+        self.animate_vadjustment_to(target.clamp(lower, max_value));
+    }
+
+    fn animate_vadjustment_to(&self, target: f64) {
+        let imp = self.imp();
+        if let Some(timeout_id) = imp.scroll_animation_timeout_id.take() {
+            timeout_id.remove();
+        }
+
+        let adj = self.vadjustment();
+        let start = adj.value();
+        if (target - start).abs() < 0.5 {
+            adj.set_value(target);
+            return;
+        }
+
+        let started_at = Instant::now();
+        let auto_scroll = self.clone();
+        let timeout_id =
+            glib::timeout_add_local(Duration::from_millis(SCROLL_ANIMATION_TICK_MS), move || {
+                let elapsed_ms = started_at.elapsed().as_secs_f64() * 1000.0;
+                let t = (elapsed_ms / SCROLL_ANIMATION_DURATION_MS).clamp(0.0, 1.0);
+
+                // ease-out cubic
+                let eased = 1.0 - (1.0 - t).powi(3);
+                let value = start + ((target - start) * eased);
+
+                auto_scroll.vadjustment().set_value(value);
+
+                if t >= 1.0 {
+                    auto_scroll.imp().scroll_animation_timeout_id.take();
+                    glib::ControlFlow::Break
+                } else {
+                    glib::ControlFlow::Continue
+                }
+            });
+
+        imp.scroll_animation_timeout_id.replace(Some(timeout_id));
     }
 }
 
@@ -85,6 +125,7 @@ mod imp {
         content: RefCell<Option<gtk::Widget>>,
 
         scroll_timeout_id: RefCell<Option<SourceId>>,
+        pub(super) scroll_animation_timeout_id: RefCell<Option<SourceId>>,
         scroll_speed: Cell<f64>,
     }
 
@@ -99,6 +140,10 @@ mod imp {
         fn start_auto_scroll(&self, drop_motion_ctrl: &gtk::DropControllerMotion) {
             if self.scroll_timeout_id.borrow().is_some() {
                 return;
+            }
+
+            if let Some(timeout_id) = self.scroll_animation_timeout_id.take() {
+                timeout_id.remove();
             }
 
             let timeout_id = glib::timeout_add_local(

--- a/src/ui/queue.rs
+++ b/src/ui/queue.rs
@@ -322,24 +322,16 @@ impl Queue {
     }
 
     fn scroll_to_current_song(&self) {
-        if let Some(audio_model) = self.get_application().audio_model() {
+        if let Some(audio_model) = self.get_application().audio_model()
+            && let Some(store) = self.imp().store.get()
+        {
             let index = audio_model.queue_index();
             if index < 0 {
                 return;
             }
-            let index = index as u32;
-
-            let Some(store) = self.imp().store.get() else {
-                return;
-            };
-
-            if index >= store.n_items() {
-                return;
-            }
-
             self.imp()
                 .scroll_window
-                .scroll_index_to_top(index, store.n_items());
+                .scroll_index_to_top(index as u32, store.n_items());
         }
     }
 }

--- a/src/ui/queue.rs
+++ b/src/ui/queue.rs
@@ -341,11 +341,9 @@ impl Queue {
             return;
         }
 
-        self.imp().track_list.scroll_to(
-            current_index,
-            gtk::ListScrollFlags::NONE,
-            None::<gtk::ScrollInfo>,
-        );
+        self.imp()
+            .scroll_window
+            .scroll_index_to_top(current_index, store.n_items());
     }
 }
 

--- a/src/ui/queue.rs
+++ b/src/ui/queue.rs
@@ -248,8 +248,9 @@ impl Queue {
         audio_model.connect_queue_index_notify(glib::clone!(
             #[weak(rename_to = queue)]
             self,
-            move |_| {
+            move |model| {
                 queue.render_status_widget();
+                queue.scroll_current_song_into_view(model.queue_index());
             }
         ));
 
@@ -272,6 +273,7 @@ impl Queue {
         // Set initial empty state
         self.set_empty(store.n_items() == 0);
         self.render_status_widget();
+        self.scroll_to_current_song();
     }
 
     // Creates an action group for the clear and save buttons that are outside of this widget
@@ -307,16 +309,43 @@ impl Queue {
         if let Some(audio_model) = self.get_application().audio_model() {
             let queue_size = audio_model.queue_size();
             let current_index = audio_model.queue_index();
-            let position_text = if queue_size == 0 {
+            let position_text = if queue_size == 0 || current_index < 0 {
                 "0 / 0".to_string()
             } else {
                 format!("{} / {}", current_index + 1, queue_size)
             };
             let duration_text = format_duration(audio_model.queue_total_duration());
 
-            imp.queue_position.set_text(&position_text);
+            imp.queue_position.set_label(&position_text);
             imp.queue_duration.set_text(&duration_text);
         }
+    }
+
+    fn scroll_to_current_song(&self) {
+        if let Some(audio_model) = self.get_application().audio_model() {
+            self.scroll_current_song_into_view(audio_model.queue_index());
+        }
+    }
+
+    fn scroll_current_song_into_view(&self, index: i32) {
+        if index < 0 {
+            return;
+        }
+
+        let Some(store) = self.imp().store.get() else {
+            return;
+        };
+
+        let current_index = index as u32;
+        if current_index >= store.n_items() {
+            return;
+        }
+
+        self.imp().track_list.scroll_to(
+            current_index,
+            gtk::ListScrollFlags::NONE,
+            None::<gtk::ScrollInfo>,
+        );
     }
 }
 
@@ -337,15 +366,19 @@ mod imp {
         prelude::*,
     };
 
+    use crate::ui::auto_scroll_window::AutoScrollWindow;
+
     #[derive(CompositeTemplate, Default)]
     #[template(resource = "/io/m51/Gelly/ui/queue.ui")]
     pub struct Queue {
         #[template_child]
         pub empty: TemplateChild<adw::StatusPage>,
         #[template_child]
+        pub scroll_window: TemplateChild<AutoScrollWindow>,
+        #[template_child]
         pub track_list: TemplateChild<gtk::ListView>,
         #[template_child]
-        pub queue_position: TemplateChild<gtk::Label>,
+        pub queue_position: TemplateChild<gtk::Button>,
         #[template_child]
         pub queue_duration: TemplateChild<gtk::Label>,
         pub store: OnceCell<gio::ListStore>,
@@ -392,6 +425,14 @@ mod imp {
                 self,
                 move |_, position| {
                     imp.obj().song_selected(position as usize);
+                }
+            ));
+
+            self.queue_position.connect_clicked(glib::clone!(
+                #[weak(rename_to = imp)]
+                self,
+                move |_| {
+                    imp.obj().scroll_to_current_song();
                 }
             ));
         }

--- a/src/ui/queue.rs
+++ b/src/ui/queue.rs
@@ -1,6 +1,7 @@
 use crate::{
     async_utils::spawn_tokio,
     i18n::tr,
+    jellyfin::utils::format_duration,
     models::SongModel,
     ui::{
         playlist_dialogs,
@@ -244,8 +245,33 @@ impl Queue {
             }
         ));
 
+        audio_model.connect_queue_index_notify(glib::clone!(
+            #[weak(rename_to = queue)]
+            self,
+            move |_| {
+                queue.render_status_widget();
+            }
+        ));
+
+        audio_model.connect_queue_size_notify(glib::clone!(
+            #[weak(rename_to = queue)]
+            self,
+            move |_| {
+                queue.render_status_widget();
+            }
+        ));
+
+        audio_model.connect_queue_total_duration_notify(glib::clone!(
+            #[weak(rename_to = queue)]
+            self,
+            move |_| {
+                queue.render_status_widget();
+            }
+        ));
+
         // Set initial empty state
         self.set_empty(store.n_items() == 0);
+        self.render_status_widget();
     }
 
     // Creates an action group for the clear and save buttons that are outside of this widget
@@ -275,6 +301,23 @@ impl Queue {
         self.get_root_window()
             .insert_action_group("queue", Some(&actions));
     }
+
+    fn render_status_widget(&self) {
+        let imp = self.imp();
+        if let Some(audio_model) = self.get_application().audio_model() {
+            let queue_size = audio_model.queue_size();
+            let current_index = audio_model.queue_index();
+            let position_text = if queue_size == 0 {
+                "0 / 0".to_string()
+            } else {
+                format!("{} / {}", current_index + 1, queue_size)
+            };
+            let duration_text = format_duration(audio_model.queue_total_duration());
+
+            imp.queue_position.set_text(&position_text);
+            imp.queue_duration.set_text(&duration_text);
+        }
+    }
 }
 
 impl Default for Queue {
@@ -301,6 +344,10 @@ mod imp {
         pub empty: TemplateChild<adw::StatusPage>,
         #[template_child]
         pub track_list: TemplateChild<gtk::ListView>,
+        #[template_child]
+        pub queue_position: TemplateChild<gtk::Label>,
+        #[template_child]
+        pub queue_duration: TemplateChild<gtk::Label>,
         pub store: OnceCell<gio::ListStore>,
     }
 

--- a/src/ui/queue.rs
+++ b/src/ui/queue.rs
@@ -318,6 +318,7 @@ impl Queue {
 
             imp.queue_position.set_label(&position_text);
             imp.queue_duration.set_text(&duration_text);
+            imp.queue_position.set_cursor_from_name(Some("pointer"));
         }
     }
 

--- a/src/ui/queue.rs
+++ b/src/ui/queue.rs
@@ -248,9 +248,8 @@ impl Queue {
         audio_model.connect_queue_index_notify(glib::clone!(
             #[weak(rename_to = queue)]
             self,
-            move |model| {
+            move |_| {
                 queue.render_status_widget();
-                queue.scroll_current_song_into_view(model.queue_index());
             }
         ));
 
@@ -324,27 +323,24 @@ impl Queue {
 
     fn scroll_to_current_song(&self) {
         if let Some(audio_model) = self.get_application().audio_model() {
-            self.scroll_current_song_into_view(audio_model.queue_index());
+            let index = audio_model.queue_index();
+            if index < 0 {
+                return;
+            }
+            let index = index as u32;
+
+            let Some(store) = self.imp().store.get() else {
+                return;
+            };
+
+            if index >= store.n_items() {
+                return;
+            }
+
+            self.imp()
+                .scroll_window
+                .scroll_index_to_top(index, store.n_items());
         }
-    }
-
-    fn scroll_current_song_into_view(&self, index: i32) {
-        if index < 0 {
-            return;
-        }
-
-        let Some(store) = self.imp().store.get() else {
-            return;
-        };
-
-        let current_index = index as u32;
-        if current_index >= store.n_items() {
-            return;
-        }
-
-        self.imp()
-            .scroll_window
-            .scroll_index_to_top(current_index, store.n_items());
     }
 }
 


### PR DESCRIPTION
Adds a current/total count button at the bottom of the queue widget that will jump to the currently playing song in the queue when pressed. Also displays total playtime.

<img width="1094" height="1035" alt="image" src="https://github.com/user-attachments/assets/2e321bf2-cb42-46ee-af6c-0a9a40f21344" />
