### PR TITLE
Song artist

### DIFF
--- a/resources/style.css
+++ b/resources/style.css
@@ -8,14 +8,6 @@
     padding-left: 7px; /* 12 minus border-left */
 }
 
-.song-link {
-    font-weight: normal;
-    padding: 0;
-    margin: 0;
-    min-width: 0;
-    min-height: 0;
-}
-
 progressbar.osd {
     margin-top: 3em;
 }

--- a/resources/ui/player_bar/big_player.ui
+++ b/resources/ui/player_bar/big_player.ui
@@ -236,6 +236,14 @@
                 </property>
               </object>
             </child>
+            <child>
+              <object class="GtkMenuButton" id="action_menu">
+                <property name="icon-name">view-more-symbolic</property>
+                <style>
+                  <class name="flat"/>
+                </style>
+              </object>
+            </child>
           </object>
         </child>
       </object>

--- a/resources/ui/player_bar/big_player.ui
+++ b/resources/ui/player_bar/big_player.ui
@@ -41,21 +41,9 @@
                 <property name="valign">center</property>
                 <property name="hexpand">true</property>
                 <child>
-                  <object class="GtkButton" id="artist_button">
-                    <property name="focusable">True</property>
-                    <property name="halign">start</property>
-                    <property name="has-frame">False</property>
-                    <style>
-                      <class name="flat"/>
-                      <class name="dimmed"/>
-                      <class name="song-link"/>
-                    </style>
-                    <property name="child">
-                      <object class="GtkLabel" id="artist_label">
-                        <property name="ellipsize">end</property>
-                        <property name="max_width_chars">90</property>
-                      </object>
-                    </property>
+                  <object class="GtkLabel" id="artist_label">
+                    <property name="ellipsize">end</property>
+                    <property name="max_width_chars">90</property>
                   </object>
                 </child>
                 <child>
@@ -69,21 +57,9 @@
                   </object>
                 </child>
                 <child>
-                  <object class="GtkButton" id="album_button">
-                    <property name="focusable">True</property>
-                    <property name="halign">start</property>
-                    <property name="has-frame">False</property>
-                    <style>
-                      <class name="flat"/>
-                      <class name="dimmed"/>
-                      <class name="song-link"/>
-                    </style>
-                    <property name="child">
-                      <object class="GtkLabel" id="album_label">
-                        <property name="ellipsize">end</property>
-                        <property name="max_width_chars">90</property>
-                      </object>
-                    </property>
+                  <object class="GtkLabel" id="album_label">
+                    <property name="ellipsize">end</property>
+                    <property name="max_width_chars">90</property>
                   </object>
                 </child>
               </object>

--- a/resources/ui/player_bar/big_player.ui
+++ b/resources/ui/player_bar/big_player.ui
@@ -44,6 +44,9 @@
                   <object class="GtkLabel" id="artist_label">
                     <property name="ellipsize">end</property>
                     <property name="max_width_chars">90</property>
+                    <style>
+                      <class name="dimmed"/>
+                    </style>
                   </object>
                 </child>
                 <child>
@@ -60,6 +63,9 @@
                   <object class="GtkLabel" id="album_label">
                     <property name="ellipsize">end</property>
                     <property name="max_width_chars">90</property>
+                    <style>
+                      <class name="dimmed"/>
+                    </style>
                   </object>
                 </child>
               </object>

--- a/resources/ui/player_bar/compact_player_bar.ui
+++ b/resources/ui/player_bar/compact_player_bar.ui
@@ -164,18 +164,10 @@
               <object class="GtkBox">
                 <property name="visible">false</property>
                 <child>
-                  <object class="GtkButton" id="artist_button">
-                    <property name="child">
-                      <object class="GtkLabel" id="artist_label"/>
-                    </property>
-                  </object>
+                  <object class="GtkLabel" id="artist_label"/>
                 </child>
                 <child>
-                  <object class="GtkButton" id="album_button">
-                    <property name="child">
-                      <object class="GtkLabel" id="album_label"/>
-                    </property>
-                  </object>
+                  <object class="GtkLabel" id="album_label"/>
                 </child>
                 <child>
                   <object class="GtkButton" id="info_button"/>

--- a/resources/ui/player_bar/compact_player_bar.ui
+++ b/resources/ui/player_bar/compact_player_bar.ui
@@ -196,6 +196,14 @@
                 <child>
                   <object class="GellyPlaybackModeMenu" id="playback_mode_menu"/>
                 </child>
+                <child>
+                  <object class="GtkMenuButton" id="action_menu">
+                    <property name="icon-name">view-more-symbolic</property>
+                    <style>
+                      <class name="flat"/>
+                    </style>
+                  </object>
+                </child>
               </object>
             </child>
           </object>

--- a/resources/ui/player_bar/full_player_bar.ui
+++ b/resources/ui/player_bar/full_player_bar.ui
@@ -71,21 +71,12 @@
                             <property name="halign">center</property>
                             <property name="margin-bottom">2</property>
                             <child>
-                              <object class="GtkButton" id="artist_button">
-                                <property name="focusable">True</property>
-                                <property name="halign">end</property>
-                                <property name="has-frame">False</property>
-                                <style>
-                                  <class name="flat"/>
-                                  <class name="dimmed"/>
-                                  <class name="song-link"/>
-                                </style>
-                                <property name="child">
-                                  <object class="GtkLabel" id="artist_label">
-                                    <property name="ellipsize">end</property>
-                                    <property name="max_width_chars">90</property>
-                                  </object>
-                                </property>
+                              <object class="GtkLabel" id="artist_label">
+                                <property name="ellipsize">end</property>
+                                <property name="max_width_chars">90</property>
+                                  <style>
+                                    <class name="dimmed"/>
+                                  </style>
                               </object>
                             </child>
                             <child>
@@ -99,22 +90,13 @@
                               </object>
                             </child>
                             <child>
-                              <object class="GtkButton" id="album_button">
-                                <property name="focusable">True</property>
-                                <property name="has-frame">False</property>
+                              <object class="GtkLabel" id="album_label">
+                                <property name="ellipsize">end</property>
                                 <property name="halign">start</property>
+                                <property name="max_width_chars">90</property>
                                 <style>
-                                  <class name="flat"/>
                                   <class name="dimmed"/>
-                                  <class name="song-link"/>
                                 </style>
-                                <property name="child">
-                                  <object class="GtkLabel" id="album_label">
-                                    <property name="ellipsize">end</property>
-                                    <property name="halign">start</property>
-                                    <property name="max_width_chars">90</property>
-                                  </object>
-                                </property>
                               </object>
                             </child>
                           </object>

--- a/resources/ui/player_bar/full_player_bar.ui
+++ b/resources/ui/player_bar/full_player_bar.ui
@@ -180,6 +180,7 @@
                     <property name="margin-end">4</property>
                     <property name="spacing">3</property>
                     <child>
+                    <!-- TODO this needs to be monospace to prevent it from jittering -->
                       <object class="GtkLabel" id="scale_position_label">
                         <property name="label">0:00</property>
                         <property name="width-chars">4</property>
@@ -211,6 +212,20 @@
                     <property name="halign">end</property>
                     <property name="valign">center</property>
                     <property name="spacing">3</property>
+                    <child>
+                      <object class="GtkButton" id="info_button">
+                        <property name="margin-start">2</property>
+                        <property name="child">
+                          <object class="GtkImage">
+                            <property name="icon-name">help-about-symbolic</property>
+                            <property name="icon-size">1</property>
+                          </object>
+                        </property>
+                        <style>
+                          <class name="flat"/>
+                        </style>
+                      </object>
+                    </child>
                     <child>
                       <object class="GtkButton" id="lyrics_button">
                         <property name="icon-name">subtitles-symbolic</property>
@@ -245,14 +260,8 @@
                     <property name="valign">center</property>
                     <property name="spacing">3</property>
                     <child>
-                      <object class="GtkButton" id="info_button">
-                        <property name="margin-start">2</property>
-                        <property name="child">
-                          <object class="GtkImage">
-                            <property name="icon-name">help-about-symbolic</property>
-                            <property name="icon-size">1</property>
-                          </object>
-                        </property>
+                      <object class="GtkMenuButton" id="action_menu">
+                        <property name="icon-name">view-more-symbolic</property>
                         <style>
                           <class name="flat"/>
                         </style>

--- a/resources/ui/song.ui
+++ b/resources/ui/song.ui
@@ -61,21 +61,13 @@
                 <property name="hexpand">True</property>
                 <property name="margin-start">9</property>
                 <child>
-                  <object class="GtkButton" id="artist_button">
-                    <property name="focusable">True</property>
+                  <object class="GtkLabel" id="artist_label">
+                    <property name="ellipsize">end</property>
+                    <property name="max_width_chars">90</property>
                     <property name="halign">start</property>
-                    <property name="has-frame">False</property>
                     <style>
-                      <class name="flat"/>
                       <class name="dimmed"/>
-                      <class name="song-link"/>
                     </style>
-                    <property name="child">
-                      <object class="GtkLabel" id="artist_label">
-                        <property name="ellipsize">end</property>
-                        <property name="max_width_chars">90</property>
-                      </object>
-                    </property>
                   </object>
                 </child>
                 <child>
@@ -90,21 +82,13 @@
                   </object>
                 </child>
                 <child>
-                  <object class="GtkButton" id="album_button">
-                    <property name="focusable">True</property>
+                  <object class="GtkLabel" id="album_label">
+                    <property name="ellipsize">end</property>
+                    <property name="max_width_chars">90</property>
                     <property name="halign">start</property>
-                    <property name="has-frame">False</property>
                     <style>
-                      <class name="flat"/>
                       <class name="dimmed"/>
-                      <class name="song-link"/>
                     </style>
-                    <property name="child">
-                      <object class="GtkLabel" id="album_label">
-                        <property name="ellipsize">end</property>
-                        <property name="max_width_chars">90</property>
-                      </object>
-                    </property>
                   </object>
                 </child>
               </object>

--- a/src/jellyfin/api.rs
+++ b/src/jellyfin/api.rs
@@ -76,6 +76,7 @@ pub struct MusicDto {
     pub run_time_ticks: u64,
     pub album: Option<String>,
     pub album_artists: Vec<ArtistItemsDto>,
+    pub artist_items: Vec<ArtistItemsDto>, // This is song artists
     pub album_id: Option<String>,
     pub normalization_gain: Option<f64>,
     pub production_year: Option<u32>,

--- a/src/library.rs
+++ b/src/library.rs
@@ -337,6 +337,7 @@ mod tests {
                 name: artist_name.to_string(),
                 id: artist_id.to_string(),
             }],
+            artist_items: vec![],
             date_created: Some("2025-01-01".to_string()),
             run_time_ticks: 2000000000,
             normalization_gain: None,
@@ -367,6 +368,7 @@ mod tests {
                     id: id.to_string(),
                 })
                 .collect(),
+            artist_items: vec![],
             date_created: Some("2025-01-01".to_string()),
             run_time_ticks: 2000000000,
             normalization_gain: None,
@@ -389,6 +391,7 @@ mod tests {
                 name: format!("user-data-{}", play_count),
                 id: format!("user-data-{}", play_count),
             }],
+            artist_items: vec![],
             date_created: Some("2025-01-01".to_string()),
             run_time_ticks: 2000000000,
             normalization_gain: None,

--- a/src/models/song_model.rs
+++ b/src/models/song_model.rs
@@ -8,11 +8,7 @@ glib::wrapper! {
 
 impl SongModel {
     pub fn new(dto: &MusicDto, favorite: bool) -> Self {
-        let artists: Vec<String> = dto
-            .album_artists
-            .iter()
-            .map(|artist| artist.name.clone())
-            .collect();
+        let artists = Self::get_artists(dto);
         let artists_string = artists.join(", ");
         let date_created = dto.date_created.clone().unwrap_or("".to_string());
         Object::builder()
@@ -34,6 +30,22 @@ impl SongModel {
 
     pub fn duration_seconds(&self) -> u64 {
         self.duration() / 10_000_000 // Jellyfin ticks
+    }
+
+    /// Attempts to prioritize song artists for display purposes. If there are no song artists,
+    /// falls back to album artists.
+    fn get_artists(dto: &MusicDto) -> Vec<String> {
+        if dto.artist_items.is_empty() {
+            dto.album_artists
+                .iter()
+                .map(|artist| artist.name.clone())
+                .collect()
+        } else {
+            dto.artist_items
+                .iter()
+                .map(|artist| artist.name.clone())
+                .collect()
+        }
     }
 }
 

--- a/src/subsonic/mod.rs
+++ b/src/subsonic/mod.rs
@@ -287,8 +287,8 @@ impl Subsonic {
                 .album_artists
                 .first()
                 .map(|artist| artist.name.clone()))
-            .or(song.album_artist)
-            .or(song.artist)
+            .or(song.album_artist.clone())
+            .or(song.artist.clone())
             .or(fallback.artist_name.clone())
             .unwrap_or_else(|| "Unknown Artist".to_string());
 
@@ -300,7 +300,18 @@ impl Subsonic {
                 .album_artists
                 .first()
                 .map(|artist| artist.id.clone()))
-            .or(song.artist_id)
+            .or(song.artist_id.clone())
+            .or(fallback.artist_id.clone())
+            .unwrap_or_default();
+
+        let song_artist_name = song
+            .artist
+            .or(song.album_artist)
+            .or(fallback.artist_name.clone())
+            .unwrap_or_else(|| "Unknown Artist".to_string());
+
+        let song_artist_id = song
+            .artist_id
             .or(fallback.artist_id.clone())
             .unwrap_or_default();
 
@@ -322,6 +333,10 @@ impl Subsonic {
             album_artists: vec![ArtistItemsDto {
                 name: artist_name,
                 id: artist_id,
+            }],
+            artist_items: vec![ArtistItemsDto {
+                name: song_artist_name,
+                id: song_artist_id,
             }],
             album_id,
             normalization_gain,

--- a/src/ui/album_detail.rs
+++ b/src/ui/album_detail.rs
@@ -205,6 +205,15 @@ impl AlbumDetail {
         }
     }
 
+    fn on_go_to_artist(&self) {
+        if let Some(song) = self.imp().songs.borrow().first()
+            && let Some(artist_model) = self.get_application().library().artist_for_item(&song.id())
+        {
+            let window = self.get_root_window();
+            window.show_artist_detail(&artist_model);
+        }
+    }
+
     fn update_track_metadata(&self) {
         let songs = self.imp().songs.borrow();
         self.imp().track_count.set_text(&songs.len().to_string());
@@ -219,6 +228,8 @@ impl AlbumDetail {
             can_remove_from_playlist: false,
             in_queue: false,
             action_prefix: "album".to_string(),
+            go_to_artist: true,
+            go_to_album: false,
         };
         let popover_menu = construct_menu(
             &options,
@@ -277,6 +288,14 @@ impl AlbumDetail {
             }
         ));
         action_group.add_action(&on_copy_id_action);
+
+        let on_go_to_artist_action = gio::SimpleAction::new("go_to_artist", None);
+        on_go_to_artist_action.connect_activate(glib::clone!(
+            #[weak(rename_to = album)]
+            self,
+            move |_, _| album.on_go_to_artist()
+        ));
+        action_group.add_action(&on_go_to_artist_action);
 
         action_group
     }

--- a/src/ui/artist_detail.rs
+++ b/src/ui/artist_detail.rs
@@ -115,6 +115,8 @@ impl ArtistDetail {
             can_remove_from_playlist: false,
             in_queue: false,
             action_prefix: "artist".to_string(),
+            go_to_album: false,
+            go_to_artist: false,
         };
         let popover_menu = construct_menu(
             &options,

--- a/src/ui/music_context_menu.rs
+++ b/src/ui/music_context_menu.rs
@@ -8,6 +8,8 @@ pub struct ContextActions {
     pub can_remove_from_playlist: bool,
     pub in_queue: bool,
     pub action_prefix: String,
+    pub go_to_artist: bool,
+    pub go_to_album: bool,
 }
 
 pub fn construct_menu(
@@ -67,6 +69,22 @@ fn create_menu_model(config: &ContextActions, playlists: &[PlaylistDto]) -> gio:
         );
     }
     menu.append_section(None, &playlist_section);
+
+    let navigation_section = gio::Menu::new();
+    if config.go_to_album {
+        navigation_section.append(
+            Some(&tr("Go to Album")),
+            Some(&format!("{}.go_to_album", config.action_prefix)),
+        );
+    }
+
+    if config.go_to_artist {
+        navigation_section.append(
+            Some(&tr("Go to Artist")),
+            Some(&format!("{}.go_to_artist", config.action_prefix)),
+        );
+    }
+    menu.append_section(None, &navigation_section);
 
     let other_section = gio::Menu::new();
     other_section.append(

--- a/src/ui/player_bar/big_player.rs
+++ b/src/ui/player_bar/big_player.rs
@@ -152,6 +152,8 @@ mod imp {
         pub favorite_button: TemplateChild<gtk::ToggleButton>,
         #[template_child]
         pub playback_mode_menu: TemplateChild<PlaybackModeMenu>,
+        #[template_child]
+        pub action_menu: TemplateChild<gtk::MenuButton>,
 
         pub audio_model: OnceCell<AudioModel>,
         pub lyrics_window: RefCell<Option<WeakRef<adw::Window>>>,
@@ -189,6 +191,7 @@ mod imp {
             self.parent_constructed();
             self.setup_common_signals();
             self.setup_clickable_labels();
+            self.setup_menu();
             self.setup_volume_icons();
 
             self.album_art.connect_closure(
@@ -279,6 +282,9 @@ mod imp {
         }
         fn album_art(&self) -> &AlbumArt {
             &self.album_art
+        }
+        fn action_menu(&self) -> &gtk::MenuButton {
+            &self.action_menu
         }
     }
 

--- a/src/ui/player_bar/big_player.rs
+++ b/src/ui/player_bar/big_player.rs
@@ -123,11 +123,7 @@ mod imp {
         #[template_child]
         pub title_label: TemplateChild<gtk::Label>,
         #[template_child]
-        pub artist_button: TemplateChild<gtk::Button>,
-        #[template_child]
         pub artist_label: TemplateChild<gtk::Label>,
-        #[template_child]
-        pub album_button: TemplateChild<gtk::Button>,
         #[template_child]
         pub album_label: TemplateChild<gtk::Label>,
         #[template_child]
@@ -190,7 +186,6 @@ mod imp {
         fn constructed(&self) {
             self.parent_constructed();
             self.setup_common_signals();
-            self.setup_clickable_labels();
             self.setup_menu();
             self.setup_volume_icons();
 
@@ -264,12 +259,6 @@ mod imp {
         }
         fn favorite_binding(&self) -> &RefCell<Option<glib::Binding>> {
             &self.favorite_binding
-        }
-        fn artist_button(&self) -> &gtk::Button {
-            &self.artist_button
-        }
-        fn album_button(&self) -> &gtk::Button {
-            &self.album_button
         }
         fn title_label(&self) -> &gtk::Label {
             &self.title_label

--- a/src/ui/player_bar/common.rs
+++ b/src/ui/player_bar/common.rs
@@ -49,8 +49,6 @@ where
     fn position_label(&self) -> &gtk::Label;
     fn duration_label(&self) -> &gtk::Label;
     fn lyrics_button(&self) -> &gtk::Button;
-    fn artist_button(&self) -> &gtk::Button;
-    fn album_button(&self) -> &gtk::Button;
     fn title_label(&self) -> &gtk::Label;
     fn artist_label(&self) -> &gtk::Label;
     fn album_label(&self) -> &gtk::Label;
@@ -243,29 +241,6 @@ where
         {
             window.show_album_detail(&album_model);
         }
-    }
-
-    fn setup_clickable_labels(&self) {
-        self.artist_button().set_cursor_from_name(Some("pointer"));
-        self.album_button().set_cursor_from_name(Some("pointer"));
-
-        let weak = self.obj().downgrade();
-        self.artist_button().connect_clicked({
-            let weak = weak.clone();
-            move |_| {
-                if let Some(obj) = weak.upgrade() {
-                    obj.imp().on_go_to_artist();
-                }
-            }
-        });
-        self.album_button().connect_clicked({
-            let weak = weak.clone();
-            move |_| {
-                if let Some(obj) = weak.upgrade() {
-                    obj.imp().on_go_to_album();
-                }
-            }
-        });
     }
 
     fn on_add_to_playlist(&self, playlist_id: String) {

--- a/src/ui/player_bar/common.rs
+++ b/src/ui/player_bar/common.rs
@@ -4,12 +4,19 @@ use crate::{
     i18n::tr,
     jellyfin::api::ItemType,
     ui::{
-        album_art::AlbumArt, lyrics::Lyrics, stream_info_dialog, widget_ext::WidgetApplicationExt,
+        album_art::AlbumArt,
+        lyrics::Lyrics,
+        music_context_menu::{ContextActions, construct_menu},
+        stream_info_dialog,
+        widget_ext::WidgetApplicationExt,
     },
 };
 use adw::prelude::*;
 use glib::{WeakRef, object::ObjectSubclassIs, subclass::prelude::*};
-use gtk::glib;
+use gtk::{
+    gio::{SimpleAction, SimpleActionGroup},
+    glib,
+};
 use log::warn;
 use std::cell::RefCell;
 
@@ -49,6 +56,7 @@ where
     fn album_label(&self) -> &gtk::Label;
     fn album_art(&self) -> &AlbumArt;
     fn favorite_button(&self) -> &gtk::ToggleButton;
+    fn action_menu(&self) -> &gtk::MenuButton;
 
     fn snapshot_background(&self, snapshot: &gtk::Snapshot) {
         let obj = self.obj();
@@ -211,7 +219,7 @@ where
         }
     }
 
-    fn show_artist(&self) {
+    fn on_go_to_artist(&self) {
         let song_id = self.audio_model().current_song_id();
         let window = self.obj().get_root_window();
         if let Some(artist_model) = self
@@ -224,7 +232,7 @@ where
         }
     }
 
-    fn show_album(&self) {
+    fn on_go_to_album(&self) {
         let song_id = self.audio_model().current_song_id();
         let window = self.obj().get_root_window();
         if let Some(album_model) = self
@@ -246,7 +254,7 @@ where
             let weak = weak.clone();
             move |_| {
                 if let Some(obj) = weak.upgrade() {
-                    obj.imp().show_artist();
+                    obj.imp().on_go_to_artist();
                 }
             }
         });
@@ -254,10 +262,109 @@ where
             let weak = weak.clone();
             move |_| {
                 if let Some(obj) = weak.upgrade() {
-                    obj.imp().show_album();
+                    obj.imp().on_go_to_album();
                 }
             }
         });
+    }
+
+    fn on_add_to_playlist(&self, playlist_id: String) {
+        let song_id = self.audio_model().current_song_id();
+        let app = self.obj().get_application();
+        let backend = app.backend();
+        let weak = self.obj().downgrade();
+        spawn_tokio(
+            async move { backend.add_playlist_items(&playlist_id, &[song_id]).await },
+            move |result| {
+                if let Some(player) = weak.upgrade() {
+                    match result {
+                        Ok(()) => {
+                            player.toast(&tr("Added song to playlist"), None);
+                            app.refresh_playlists(true);
+                        }
+                        Err(e) => {
+                            player.toast(&tr("Failed to add song to playlist"), None);
+                            warn!("Failed to add song to playlist: {}", e);
+                        }
+                    }
+                }
+            },
+        );
+    }
+
+    fn on_queue_next(&self) {
+        if let Some(song_model) = self.audio_model().current_song() {
+            self.audio_model().prepend_to_queue(vec![song_model]);
+        }
+    }
+
+    fn on_queue_last(&self) {
+        if let Some(song_model) = self.audio_model().current_song() {
+            self.audio_model().append_to_queue(vec![song_model]);
+        }
+    }
+
+    fn on_copy_id(&self) {
+        let id = self.audio_model().current_song_id();
+        self.obj().clipboard().set_text(&id);
+        self.obj().toast(&tr("Song ID copied to clipboard"), None);
+    }
+
+    fn setup_menu(&self) {
+        let options = ContextActions {
+            can_remove_from_playlist: false,
+            in_queue: false,
+            action_prefix: "song".to_string(),
+            go_to_artist: true,
+            go_to_album: true,
+        };
+        let weak = self.obj().downgrade();
+        let menu = construct_menu(&options, move || {
+            if let Some(obj) = weak.upgrade() {
+                obj.get_application().playlists().borrow().clone()
+            } else {
+                Vec::new()
+            }
+        });
+        self.action_menu().set_popover(Some(&menu));
+        let action_group = self.create_action_group();
+        self.obj()
+            .insert_action_group(&options.action_prefix, Some(&action_group));
+    }
+
+    fn create_action_group(&self) -> SimpleActionGroup {
+        let action_group = SimpleActionGroup::new();
+
+        let add_noarg_action = |name: &str, handler: fn(&Self)| {
+            let action = SimpleAction::new(name, None);
+            let weak = self.obj().downgrade();
+            action.connect_activate(move |_, _| {
+                if let Some(player) = weak.upgrade() {
+                    handler(player.imp());
+                }
+            });
+            action_group.add_action(&action);
+        };
+
+        let add_to_playlist_action =
+            SimpleAction::new("add_to_playlist", Some(glib::VariantTy::STRING));
+        let weak = self.obj().downgrade();
+        add_to_playlist_action.connect_activate(move |_, playlist_id| {
+            if let Some(player) = weak.upgrade()
+                && let Some(playlist_id) = playlist_id.and_then(|id| id.get::<String>())
+            {
+                player.imp().on_add_to_playlist(playlist_id);
+            }
+        });
+        action_group.add_action(&add_to_playlist_action);
+
+        add_noarg_action("queue_next", Self::on_queue_next);
+        add_noarg_action("queue_last", Self::on_queue_last);
+        add_noarg_action("copy_id", Self::on_copy_id);
+        add_noarg_action("go_to_album", Self::on_go_to_album);
+        add_noarg_action("go_to_artist", Self::on_go_to_artist);
+
+        action_group
     }
 
     fn setup_volume_icons(&self) {

--- a/src/ui/player_bar/compact_player_bar.rs
+++ b/src/ui/player_bar/compact_player_bar.rs
@@ -118,11 +118,7 @@ mod imp {
         #[template_child]
         pub title_label: TemplateChild<gtk::Label>,
         #[template_child]
-        pub artist_button: TemplateChild<gtk::Button>,
-        #[template_child]
         pub artist_label: TemplateChild<gtk::Label>,
-        #[template_child]
-        pub album_button: TemplateChild<gtk::Button>,
         #[template_child]
         pub album_label: TemplateChild<gtk::Label>,
         #[template_child]
@@ -181,7 +177,6 @@ mod imp {
         fn constructed(&self) {
             self.parent_constructed();
             self.setup_common_signals();
-            self.setup_clickable_labels();
             self.setup_menu();
             self.setup_volume_icons();
         }
@@ -243,12 +238,6 @@ mod imp {
         }
         fn favorite_binding(&self) -> &RefCell<Option<glib::Binding>> {
             &self.favorite_binding
-        }
-        fn artist_button(&self) -> &gtk::Button {
-            &self.artist_button
-        }
-        fn album_button(&self) -> &gtk::Button {
-            &self.album_button
         }
         fn title_label(&self) -> &gtk::Label {
             &self.title_label

--- a/src/ui/player_bar/compact_player_bar.rs
+++ b/src/ui/player_bar/compact_player_bar.rs
@@ -147,6 +147,8 @@ mod imp {
         pub favorite_button: TemplateChild<gtk::ToggleButton>,
         #[template_child]
         pub playback_mode_menu: TemplateChild<PlaybackModeMenu>,
+        #[template_child]
+        pub action_menu: TemplateChild<gtk::MenuButton>,
 
         pub audio_model: OnceCell<AudioModel>,
         pub lyrics_window: RefCell<Option<WeakRef<adw::Window>>>,
@@ -180,6 +182,7 @@ mod imp {
             self.parent_constructed();
             self.setup_common_signals();
             self.setup_clickable_labels();
+            self.setup_menu();
             self.setup_volume_icons();
         }
     }
@@ -258,6 +261,9 @@ mod imp {
         }
         fn album_art(&self) -> &AlbumArt {
             &self.album_art
+        }
+        fn action_menu(&self) -> &gtk::MenuButton {
+            &self.action_menu
         }
     }
 }

--- a/src/ui/player_bar/full_player_bar.rs
+++ b/src/ui/player_bar/full_player_bar.rs
@@ -151,6 +151,8 @@ mod imp {
         pub favorite_button: TemplateChild<gtk::ToggleButton>,
         #[template_child]
         pub playback_mode_menu: TemplateChild<PlaybackModeMenu>,
+        #[template_child]
+        pub action_menu: TemplateChild<gtk::MenuButton>,
 
         pub audio_model: OnceCell<AudioModel>,
         pub lyrics_window: RefCell<Option<WeakRef<adw::Window>>>,
@@ -184,6 +186,7 @@ mod imp {
             self.parent_constructed();
             self.setup_common_signals();
             self.setup_clickable_labels();
+            self.setup_menu();
             self.setup_volume_icons();
         }
     }
@@ -272,6 +275,9 @@ mod imp {
         fn extra_duration_update(&self, duration: u32) {
             self.scale_duration_label
                 .set_text(&crate::ui::player_bar::common::format_time(duration));
+        }
+        fn action_menu(&self) -> &gtk::MenuButton {
+            &self.action_menu
         }
     }
 }

--- a/src/ui/player_bar/full_player_bar.rs
+++ b/src/ui/player_bar/full_player_bar.rs
@@ -118,11 +118,7 @@ mod imp {
         #[template_child]
         pub title_label: TemplateChild<gtk::Label>,
         #[template_child]
-        pub artist_button: TemplateChild<gtk::Button>,
-        #[template_child]
         pub artist_label: TemplateChild<gtk::Label>,
-        #[template_child]
-        pub album_button: TemplateChild<gtk::Button>,
         #[template_child]
         pub album_label: TemplateChild<gtk::Label>,
         #[template_child]
@@ -185,7 +181,6 @@ mod imp {
         fn constructed(&self) {
             self.parent_constructed();
             self.setup_common_signals();
-            self.setup_clickable_labels();
             self.setup_menu();
             self.setup_volume_icons();
         }
@@ -247,12 +242,6 @@ mod imp {
         }
         fn favorite_binding(&self) -> &RefCell<Option<glib::Binding>> {
             &self.favorite_binding
-        }
-        fn artist_button(&self) -> &gtk::Button {
-            &self.artist_button
-        }
-        fn album_button(&self) -> &gtk::Button {
-            &self.album_button
         }
         fn title_label(&self) -> &gtk::Label {
             &self.title_label

--- a/src/ui/playlist_detail.rs
+++ b/src/ui/playlist_detail.rs
@@ -279,6 +279,8 @@ impl PlaylistDetail {
             can_remove_from_playlist: false,
             in_queue: false,
             action_prefix: "playlist_detail".to_string(),
+            go_to_album: false,
+            go_to_artist: false,
         };
         let popover_menu = construct_menu(
             &options,

--- a/src/ui/song.rs
+++ b/src/ui/song.rs
@@ -287,29 +287,6 @@ impl Song {
         action_group
     }
 
-    fn setup_clickable_labels(&self) {
-        let imp = self.imp();
-        // Set pointer cursor for better discoverability
-        imp.artist_button.set_cursor_from_name(Some("pointer"));
-        imp.album_button.set_cursor_from_name(Some("pointer"));
-
-        imp.artist_button.connect_clicked(glib::clone!(
-            #[weak(rename_to = song)]
-            self,
-            move |_| {
-                song.emit_by_name::<()>("artist-clicked", &[&song.song_id()]);
-            }
-        ));
-
-        imp.album_button.connect_clicked(glib::clone!(
-            #[weak(rename_to = song)]
-            self,
-            move |_| {
-                song.emit_by_name::<()>("album-clicked", &[&song.song_id()]);
-            }
-        ));
-    }
-
     fn on_add_to_playlist(&self, playlist_id: String) {
         let song_id = self.song_id();
         let app = self.get_application();
@@ -400,11 +377,7 @@ mod imp {
         #[template_child]
         pub artist_box: TemplateChild<gtk::Box>,
         #[template_child]
-        pub artist_button: TemplateChild<gtk::Button>,
-        #[template_child]
         pub artist_label: TemplateChild<gtk::Label>,
-        #[template_child]
-        pub album_button: TemplateChild<gtk::Button>,
         #[template_child]
         pub album_label: TemplateChild<gtk::Label>,
         #[template_child]
@@ -477,7 +450,6 @@ mod imp {
         fn constructed(&self) {
             self.parent_constructed();
             self.obj().setup_menu();
-            self.obj().setup_clickable_labels();
 
             // Sadly this can't be done in the template itself
             let orientation = if self.in_queue.get() {

--- a/src/ui/song.rs
+++ b/src/ui/song.rs
@@ -217,6 +217,8 @@ impl Song {
     fn create_action_group(&self) -> SimpleActionGroup {
         let action_group = SimpleActionGroup::new();
 
+        // TODO add helper here like in the player bar implementation
+
         let add_to_playlist_action =
             gio::SimpleAction::new("add_to_playlist", Some(glib::VariantTy::STRING));
         add_to_playlist_action.connect_activate(glib::clone!(

--- a/src/ui/song.rs
+++ b/src/ui/song.rs
@@ -197,6 +197,8 @@ impl Song {
             can_remove_from_playlist: self.imp().in_playlist.get(),
             in_queue: self.imp().in_queue.get(),
             action_prefix: "song".to_string(),
+            go_to_album: true,
+            go_to_artist: true,
         };
         let popover_menu = construct_menu(
             &options,
@@ -263,6 +265,22 @@ impl Song {
             }
         ));
         action_group.add_action(&on_copy_id_action);
+
+        let on_go_to_album_action = gio::SimpleAction::new("go_to_album", None);
+        on_go_to_album_action.connect_activate(glib::clone!(
+            #[weak (rename_to = song)]
+            self,
+            move |_, _| song.on_go_to_album()
+        ));
+        action_group.add_action(&on_go_to_album_action);
+
+        let on_go_to_artist_action = gio::SimpleAction::new("go_to_artist", None);
+        on_go_to_artist_action.connect_activate(glib::clone!(
+            #[weak (rename_to = song)]
+            self,
+            move |_, _| song.on_go_to_artist()
+        ));
+        action_group.add_action(&on_go_to_artist_action);
 
         action_group
     }
@@ -336,6 +354,14 @@ impl Song {
         {
             audio_model.append_to_queue(vec![song_model]);
         }
+    }
+
+    fn on_go_to_album(&self) {
+        self.emit_by_name::<()>("album-clicked", &[&self.song_id()]);
+    }
+
+    fn on_go_to_artist(&self) {
+        self.emit_by_name::<()>("artist-clicked", &[&self.song_id()]);
     }
 }
 


### PR DESCRIPTION
Tracks should now display their song specific artists, while keeping the album list to album artists only.

<img width="829" height="900" alt="image" src="https://github.com/user-attachments/assets/d5be4aca-9039-4c7f-83a4-be48e26d1137" />

In addition, the clickable labels to navigate to album/artist have been removed, as that would have created inconsistent navigation. Instead, go to artist and album actions have been added to the context menus where appropriate.

Fixes #60 
Fixes #116 