### PR TITLE
More song info

### DIFF
--- a/resources/ui/player_bar/big_player.ui
+++ b/resources/ui/player_bar/big_player.ui
@@ -164,21 +164,6 @@
             <property name="halign">center</property>
             <property name="spacing">6</property>
             <child>
-              <object class="GtkButton" id="info_button">
-                <property name="margin-start">2</property>
-                <property name="child">
-                  <object class="GtkImage" id="info_icon">
-                    <property name="icon-name">help-about-symbolic</property>
-                    <property name="icon-size">1</property>
-                    <property name="tooltip-text" translatable="yes">Stream Info</property>
-                  </object>
-                </property>
-                <style>
-                  <class name="flat"/>
-                </style>
-              </object>
-            </child>
-            <child>
               <object class="GtkButton" id="lyrics_button">
                 <property name="icon-name">subtitles-symbolic</property>
                 <property name="tooltip-text" translatable="yes">Lyrics</property>

--- a/resources/ui/player_bar/compact_player_bar.ui
+++ b/resources/ui/player_bar/compact_player_bar.ui
@@ -173,9 +173,6 @@
                   <object class="GtkLabel" id="album_label"/>
                 </child>
                 <child>
-                  <object class="GtkButton" id="info_button"/>
-                </child>
-                <child>
                   <object class="GtkScaleButton" id="volume_control">
                     <property name="adjustment">
                       <object class="GtkAdjustment">

--- a/resources/ui/player_bar/full_player_bar.ui
+++ b/resources/ui/player_bar/full_player_bar.ui
@@ -193,21 +193,6 @@
                     <property name="valign">center</property>
                     <property name="spacing">3</property>
                     <child>
-                      <object class="GtkButton" id="info_button">
-                        <property name="margin-start">2</property>
-                        <property name="child">
-                          <object class="GtkImage">
-                            <property name="icon-name">help-about-symbolic</property>
-                            <property name="icon-size">1</property>
-                            <property name="tooltip-text" translatable="yes">Stream Info</property>
-                          </object>
-                        </property>
-                        <style>
-                          <class name="flat"/>
-                        </style>
-                      </object>
-                    </child>
-                    <child>
                       <object class="GtkButton" id="lyrics_button">
                         <property name="icon-name">subtitles-symbolic</property>
                         <property name="tooltip-text" translatable="yes">Lyrics</property>

--- a/src/audio/stream_info.rs
+++ b/src/audio/stream_info.rs
@@ -19,6 +19,9 @@ pub enum StreamInfoError {
 
 #[derive(Default, Debug)]
 pub struct StreamInfo {
+    // File properties
+    pub id: Option<String>,
+    pub path: Option<String>,
     // Gstreamer properties
     pub codec: Option<String>,
     pub sample_rate: Option<i32>,
@@ -99,6 +102,7 @@ pub fn discover_stream_info(
                     stream_info.supports_direct_play = media_source.supports_direct_play;
                     stream_info.supports_direct_stream = media_source.supports_direct_stream;
                     stream_info.supports_transcoding = media_source.supports_transcoding;
+                    stream_info.path = media_source.path.clone();
 
                     for media_stream in &media_source.media_streams {
                         if media_stream.type_ == Some("Audio".to_string()) {
@@ -110,7 +114,7 @@ pub fn discover_stream_info(
                         }
                     }
                 }
-
+                stream_info.id = Some(item_id);
                 Ok(stream_info)
             })
             .await

--- a/src/jellyfin/api.rs
+++ b/src/jellyfin/api.rs
@@ -174,6 +174,8 @@ pub struct MediaStream {
 pub struct MediaSource {
     #[serde(deserialize_with = "deserialize_items_skip_errors")]
     pub media_streams: Vec<MediaStream>,
+    pub id: Option<String>,
+    pub path: Option<String>,
     pub container: Option<String>,
     pub size: Option<u64>,
     pub supports_direct_stream: Option<bool>,

--- a/src/subsonic/api.rs
+++ b/src/subsonic/api.rs
@@ -172,6 +172,7 @@ pub struct Song {
     pub sampling_rate: Option<u64>,
     pub channel_count: Option<u32>,
     pub replay_gain: Option<ReplayGain>,
+    pub path: Option<String>,
 }
 
 #[derive(Debug, Clone, Deserialize)]

--- a/src/subsonic/mod.rs
+++ b/src/subsonic/mod.rs
@@ -656,6 +656,8 @@ impl Subsonic {
 
         let media_source = MediaSource {
             media_streams: vec![media_stream],
+            id: Some(song.id.clone()),
+            path: song.path.clone(),
             container: song.suffix,
             size: song.size,
             supports_direct_play: Some(true),

--- a/src/ui/album_detail.rs
+++ b/src/ui/album_detail.rs
@@ -230,6 +230,7 @@ impl AlbumDetail {
             action_prefix: "album".to_string(),
             go_to_artist: true,
             go_to_album: false,
+            show_info_dialog: false,
         };
         let popover_menu = construct_menu(&options);
         self.imp().action_menu.set_popover(Some(&popover_menu));

--- a/src/ui/artist_detail.rs
+++ b/src/ui/artist_detail.rs
@@ -117,6 +117,7 @@ impl ArtistDetail {
             action_prefix: "artist".to_string(),
             go_to_album: false,
             go_to_artist: false,
+            show_info_dialog: false,
         };
         let popover_menu = construct_menu(&options);
         self.imp().action_menu.set_popover(Some(&popover_menu));

--- a/src/ui/music_context_menu.rs
+++ b/src/ui/music_context_menu.rs
@@ -11,6 +11,7 @@ pub struct ContextActions {
     pub action_prefix: String,
     pub go_to_artist: bool,
     pub go_to_album: bool,
+    pub show_info_dialog: bool,
 }
 
 pub fn construct_menu(config: &ContextActions) -> gtk::PopoverMenu {
@@ -80,7 +81,7 @@ fn create_menu_model(config: &ContextActions) -> gio::Menu {
     // Playlist section
     let playlist_section = gio::Menu::new();
     playlist_section.append(
-        Some(&tr("Add to Playlist...")),
+        Some(&tr("Add to Playlist")),
         Some(&format!("{}.add_to_playlist_dialog", config.action_prefix)),
     );
     if config.can_remove_from_playlist {
@@ -109,10 +110,17 @@ fn create_menu_model(config: &ContextActions) -> gio::Menu {
     menu.append_section(None, &navigation_section);
 
     let other_section = gio::Menu::new();
-    other_section.append(
-        Some(&tr("Copy ID")),
-        Some(&format!("{}.copy_id", config.action_prefix)),
-    );
+    if config.show_info_dialog {
+        other_section.append(
+            Some(&tr("Song Info")),
+            Some(&format!("{}.show_info_dialog", config.action_prefix)),
+        );
+    } else {
+        other_section.append(
+            Some(&tr("Copy ID")),
+            Some(&format!("{}.copy_id", config.action_prefix)),
+        )
+    }
     menu.append_section(None, &other_section);
 
     menu

--- a/src/ui/player_bar/big_player.rs
+++ b/src/ui/player_bar/big_player.rs
@@ -141,8 +141,6 @@ mod imp {
         #[template_child]
         pub volume_control: TemplateChild<gtk::ScaleButton>,
         #[template_child]
-        pub info_button: TemplateChild<gtk::Button>,
-        #[template_child]
         pub lyrics_button: TemplateChild<gtk::Button>,
         #[template_child]
         pub favorite_button: TemplateChild<gtk::ToggleButton>,
@@ -238,9 +236,6 @@ mod imp {
         }
         fn volume_control(&self) -> &gtk::ScaleButton {
             &self.volume_control
-        }
-        fn info_button(&self) -> &gtk::Button {
-            &self.info_button
         }
         fn position_scale(&self) -> &gtk::Scale {
             &self.position_scale

--- a/src/ui/player_bar/common.rs
+++ b/src/ui/player_bar/common.rs
@@ -291,12 +291,6 @@ where
         }
     }
 
-    fn on_copy_id(&self) {
-        let id = self.audio_model().current_song_id();
-        self.obj().clipboard().set_text(&id);
-        self.obj().toast(&tr("Song ID copied to clipboard"), None);
-    }
-
     fn setup_menu(&self) {
         let options = ContextActions {
             can_remove_from_playlist: false,
@@ -304,6 +298,7 @@ where
             action_prefix: "song".to_string(),
             go_to_artist: true,
             go_to_album: true,
+            show_info_dialog: true,
         };
         let menu = construct_menu(&options);
         self.action_menu().set_popover(Some(&menu));
@@ -340,10 +335,10 @@ where
 
         add_noarg_action("queue_next", Self::on_queue_next);
         add_noarg_action("queue_last", Self::on_queue_last);
-        add_noarg_action("copy_id", Self::on_copy_id);
         add_noarg_action("go_to_album", Self::on_go_to_album);
         add_noarg_action("go_to_artist", Self::on_go_to_artist);
         add_noarg_action("add_to_playlist_dialog", Self::on_add_to_playlist_dialog);
+        add_noarg_action("show_info_dialog", Self::show_info_dialog);
 
         action_group
     }

--- a/src/ui/player_bar/common.rs
+++ b/src/ui/player_bar/common.rs
@@ -44,7 +44,6 @@ where
     fn next_button(&self) -> &gtk::Button;
     fn prev_button(&self) -> &gtk::Button;
     fn volume_control(&self) -> &gtk::ScaleButton;
-    fn info_button(&self) -> &gtk::Button;
     fn position_scale(&self) -> &gtk::Scale;
     fn position_label(&self) -> &gtk::Label;
     fn duration_label(&self) -> &gtk::Label;
@@ -400,15 +399,6 @@ where
             }
         });
         self.volume_control().add_controller(middle_click);
-
-        self.info_button().connect_clicked({
-            let weak = weak.clone();
-            move |_| {
-                if let Some(obj) = weak.upgrade() {
-                    obj.imp().show_info_dialog();
-                }
-            }
-        });
 
         self.position_scale().connect_change_value({
             let weak = weak.clone();

--- a/src/ui/player_bar/compact_player_bar.rs
+++ b/src/ui/player_bar/compact_player_bar.rs
@@ -136,8 +136,6 @@ mod imp {
         #[template_child]
         pub volume_control: TemplateChild<gtk::ScaleButton>,
         #[template_child]
-        pub info_button: TemplateChild<gtk::Button>,
-        #[template_child]
         pub lyrics_button: TemplateChild<gtk::Button>,
         #[template_child]
         pub favorite_button: TemplateChild<gtk::ToggleButton>,
@@ -217,9 +215,6 @@ mod imp {
         }
         fn volume_control(&self) -> &gtk::ScaleButton {
             &self.volume_control
-        }
-        fn info_button(&self) -> &gtk::Button {
-            &self.info_button
         }
         fn position_scale(&self) -> &gtk::Scale {
             &self.position_scale

--- a/src/ui/player_bar/full_player_bar.rs
+++ b/src/ui/player_bar/full_player_bar.rs
@@ -140,8 +140,6 @@ mod imp {
         #[template_child]
         pub volume_control: TemplateChild<gtk::ScaleButton>,
         #[template_child]
-        pub info_button: TemplateChild<gtk::Button>,
-        #[template_child]
         pub lyrics_button: TemplateChild<gtk::Button>,
         #[template_child]
         pub favorite_button: TemplateChild<gtk::ToggleButton>,
@@ -221,9 +219,6 @@ mod imp {
         }
         fn volume_control(&self) -> &gtk::ScaleButton {
             &self.volume_control
-        }
-        fn info_button(&self) -> &gtk::Button {
-            &self.info_button
         }
         fn position_scale(&self) -> &gtk::Scale {
             &self.position_scale

--- a/src/ui/playlist_detail.rs
+++ b/src/ui/playlist_detail.rs
@@ -281,6 +281,7 @@ impl PlaylistDetail {
             action_prefix: "playlist_detail".to_string(),
             go_to_album: false,
             go_to_artist: false,
+            show_info_dialog: false,
         };
         let popover_menu = construct_menu(&options);
         self.imp().action_menu.set_popover(Some(&popover_menu));

--- a/src/ui/song.rs
+++ b/src/ui/song.rs
@@ -11,11 +11,13 @@ use log::warn;
 
 use crate::{
     async_utils::spawn_tokio,
+    audio::stream_info::discover_stream_info,
     i18n::tr,
     jellyfin::{api::ItemType, utils::format_duration},
     models::SongModel,
     ui::{
         music_context_menu::{ContextActions, add_to_playlist_dialog, construct_menu},
+        stream_info_dialog,
         widget_ext::WidgetApplicationExt,
     },
 };
@@ -199,6 +201,7 @@ impl Song {
             action_prefix: "song".to_string(),
             go_to_album: true,
             go_to_artist: true,
+            show_info_dialog: true,
         };
         let popover_menu = construct_menu(&options);
         self.imp().song_menu.set_popover(Some(&popover_menu));
@@ -230,10 +233,10 @@ impl Song {
 
         add_noarg_action("queue_next", Self::on_queue_next);
         add_noarg_action("queue_last", Self::on_queue_last);
-        add_noarg_action("copy_id", Self::on_copy_id);
         add_noarg_action("go_to_album", Self::on_go_to_album);
         add_noarg_action("go_to_artist", Self::on_go_to_artist);
         add_noarg_action("add_to_playlist_dialog", Self::on_add_to_playlist_dialog);
+        add_noarg_action("show_info_dialog", Self::show_info_dialog);
 
         action_group
     }
@@ -281,6 +284,24 @@ impl Song {
         );
     }
 
+    fn show_info_dialog(&self) {
+        let song_id = self.song_id();
+        let backend = self.get_application().backend();
+        let uri = backend.get_stream_uri(&song_id);
+        discover_stream_info(
+            &uri,
+            &song_id,
+            &backend,
+            glib::clone!(
+                #[weak(rename_to = song)]
+                self,
+                move |stream_info| {
+                    stream_info_dialog::show(song.get_gtk_window().as_ref(), stream_info);
+                }
+            ),
+        );
+    }
+
     fn on_remove_from_playlist(&self) {
         self.emit_by_name::<()>("remove-from-playlist", &[&self.song_id()]);
     }
@@ -309,12 +330,6 @@ impl Song {
 
     fn on_go_to_artist(&self) {
         self.emit_by_name::<()>("artist-clicked", &[&self.song_id()]);
-    }
-
-    fn on_copy_id(&self) {
-        let id = self.song_id();
-        self.clipboard().set_text(&id);
-        self.toast(&tr("Song ID copied to clipboard"), None);
     }
 }
 

--- a/src/ui/stream_info_dialog.rs
+++ b/src/ui/stream_info_dialog.rs
@@ -117,7 +117,7 @@ pub fn show(parent: Option<&Window>, info: StreamInfo) {
 
     // Create a header bar with title
     let header_bar = adw::HeaderBar::new();
-    header_bar.set_title_widget(Some(&adw::WindowTitle::new(&tr("Stream Info"), "")));
+    header_bar.set_title_widget(Some(&adw::WindowTitle::new(&tr("Song Info"), "")));
 
     // Create a toolbar view to combine header and content
     let toolbar_view = adw::ToolbarView::new();

--- a/src/ui/stream_info_dialog.rs
+++ b/src/ui/stream_info_dialog.rs
@@ -110,6 +110,11 @@ pub fn show(parent: Option<&Window>, info: StreamInfo) {
         ));
     }
 
+    let song_props = vec![
+        (tr("Id"), info.id.unwrap_or_else(|| tr("Unknown"))),
+        (tr("Path"), info.path.unwrap_or_else(|| tr("Unknown"))),
+    ];
+
     // Create a header bar with title
     let header_bar = adw::HeaderBar::new();
     header_bar.set_title_widget(Some(&adw::WindowTitle::new(&tr("Stream Info"), "")));
@@ -128,6 +133,13 @@ pub fn show(parent: Option<&Window>, info: StreamInfo) {
     whats_in_the_box.set_margin_end(12);
 
     scrolled_window.set_child(Some(&whats_in_the_box));
+
+    let song_list_box = create_listbox(&song_props);
+    let song_label = gtk::Label::new(Some(&tr("Song Properties")));
+    song_label.set_halign(gtk::Align::Start);
+    song_label.set_css_classes(&["heading"]);
+    whats_in_the_box.append(&song_label);
+    whats_in_the_box.append(&song_list_box);
 
     let local_list_box = create_listbox(&local_props);
     let local_label = gtk::Label::new(Some(&tr("Local Properties")));


### PR DESCRIPTION
Closes #153

Adds "Song Info" to context menus where appropriate, and removes the song info button from players as it is now redundant.
<img width="801" height="902" alt="image" src="https://github.com/user-attachments/assets/d245fab0-a267-43d7-bb9c-4ed61fa08658" />

