### PR TITLE
i18n: mark player bar tooltips as translatable

### DIFF
--- a/resources/ui/player_bar/big_player.ui
+++ b/resources/ui/player_bar/big_player.ui
@@ -130,7 +130,7 @@
             <child>
               <object class="GtkButton" id="prev_button">
                 <property name="icon-name">media-skip-backward-symbolic</property>
-                <property name="tooltip-text">Previous</property>
+                <property name="tooltip-text" translatable="yes">Previous</property>
                 <property name="valign">center</property>
                 <style>
                   <class name="circular"/>
@@ -140,7 +140,7 @@
             <child>
               <object class="GtkButton" id="play_pause_button">
                 <property name="icon-name">media-playback-start-symbolic</property>
-                <property name="tooltip-text">Play</property>
+                <property name="tooltip-text" translatable="yes">Play</property>
                 <style>
                   <class name="pill"/>
                 </style>
@@ -149,7 +149,7 @@
             <child>
               <object class="GtkButton" id="next_button">
                 <property name="icon-name">media-skip-forward-symbolic</property>
-                <property name="tooltip-text">Next</property>
+                <property name="tooltip-text" translatable="yes">Next</property>
                 <property name="valign">center</property>
                 <style>
                   <class name="circular"/>

--- a/resources/ui/player_bar/compact_player_bar.ui
+++ b/resources/ui/player_bar/compact_player_bar.ui
@@ -133,7 +133,7 @@
                 <child>
                   <object class="GtkButton" id="prev_button">
                     <property name="icon-name">media-skip-backward-symbolic</property>
-                    <property name="tooltip-text">Previous</property>
+                    <property name="tooltip-text" translatable="yes">Previous</property>
                     <style>
                       <class name="circular"/>
                       <class name="flat"/>
@@ -143,7 +143,7 @@
                 <child>
                   <object class="GtkButton" id="play_pause_button">
                     <property name="icon-name">media-playback-start-symbolic</property>
-                    <property name="tooltip-text">Play</property>
+                    <property name="tooltip-text" translatable="yes">Play</property>
                     <style>
                       <class name="circular"/>
                       <class name="flat"/>
@@ -153,7 +153,7 @@
                 <child>
                   <object class="GtkButton" id="next_button">
                     <property name="icon-name">media-skip-forward-symbolic</property>
-                    <property name="tooltip-text">Next</property>
+                    <property name="tooltip-text" translatable="yes">Next</property>
                     <style>
                       <class name="circular"/>
                       <class name="flat"/>

--- a/resources/ui/player_bar/full_player_bar.ui
+++ b/resources/ui/player_bar/full_player_bar.ui
@@ -113,7 +113,7 @@
                         <child>
                           <object class="GtkButton" id="prev_button">
                             <property name="icon-name">media-skip-backward-symbolic</property>
-                            <property name="tooltip-text">Previous</property>
+                            <property name="tooltip-text" translatable="yes">Previous</property>
                             <style>
                               <class name="circular"/>
                               <class name="flat"/>
@@ -123,7 +123,7 @@
                         <child>
                           <object class="GtkButton" id="play_pause_button">
                             <property name="icon-name">media-playback-start-symbolic</property>
-                            <property name="tooltip-text">Play</property>
+                            <property name="tooltip-text" translatable="yes">Play</property>
                             <style>
                               <class name="circular"/>
                               <class name="flat"/>
@@ -133,7 +133,7 @@
                         <child>
                           <object class="GtkButton" id="next_button">
                             <property name="icon-name">media-skip-forward-symbolic</property>
-                            <property name="tooltip-text">Next</property>
+                            <property name="tooltip-text" translatable="yes">Next</property>
                             <style>
                               <class name="circular"/>
                               <class name="flat"/>


### PR DESCRIPTION
Added the missing translatable="yes" attribute to the tooltip-text of the Previous, Play, and Next buttons (across all the player bars).

Previous and Next are never set in code, so they currently remain in English in all the translations. The Play button's tooltip is updated at runtime in `update_play_pause_button`, this only happens upon state change - play and pause. The value from the .ui file is still visible at startup.

The adjacent buttons like Lyrics or Volume already had this attribute. No logic changes; only the tooltips become localizable.

Note: The strings still need to be extracted into the template via `just pot` (skipped in this PR to avoid a massive diff from renumbering).